### PR TITLE
Update typo in bootstrap 4

### DIFF
--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -22,7 +22,7 @@ h3 {
 h4 {
   font-size: 1.25rem;
 }
-h4 {
+h5 {
   font-size: 1rem;
 }
 


### PR DESCRIPTION
Seems there is a typo in bootstrap 4 alpha 6 h4 should be h5