### PR TITLE
Basic URL prefixer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ clean:
 .PHONY: build-sass run clean docker build-docker-image test
 
 test:
-	cd utils && go test
+	go test ./utils

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,7 @@ docker:
 clean:
 	rm -f $(OUTPUT_FILE) $(BINARY)
 
-.PHONY: build-sass run clean docker build-docker-image
+.PHONY: build-sass run clean docker build-docker-image test
+
+test:
+	cd utils && go test

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ clean:
 .PHONY: build-sass run clean docker build-docker-image test
 
 test:
-	go test ./utils
+	go test ./...

--- a/config.toml.example
+++ b/config.toml.example
@@ -21,6 +21,8 @@
 	longName  = "University Radio York"
 	shortName = "URY"
 
+	urlPrefix = ""
+
 	[[pageContext.pages]]
 		name = "Search"
 		url  = "search/"

--- a/structs/config.go
+++ b/structs/config.go
@@ -23,6 +23,7 @@ type Server struct {
 type PageContext struct {
 	LongName  string `toml:"longName"`
 	ShortName string `toml:"shortName"`
+	UrlPrefix string `toml:"urlPrefix"`
 	Pages     []Page
 }
 

--- a/structs/config.go
+++ b/structs/config.go
@@ -23,7 +23,7 @@ type Server struct {
 type PageContext struct {
 	LongName  string `toml:"longName"`
 	ShortName string `toml:"shortName"`
-	UrlPrefix string `toml:"urlPrefix"`
+	URLPrefix string `toml:"urlPrefix"`
 	Pages     []Page
 }
 

--- a/utils/template.go
+++ b/utils/template.go
@@ -53,6 +53,7 @@ func RenderTemplate(w http.ResponseWriter, context structs.PageContext, data int
 
 	t := template.New("base.tmpl")
 	t.Funcs(template.FuncMap{
+		"url":  func(s string) string { return fmt.Sprintf("%s%s", context.UrlPrefix, s) },
 		"html": renderHTML,
 		"limitShowMeta": func(a []myradio.ShowMeta, start int, end int) []myradio.ShowMeta {
 			if len(a) < end {

--- a/utils/template.go
+++ b/utils/template.go
@@ -53,7 +53,7 @@ func RenderTemplate(w http.ResponseWriter, context structs.PageContext, data int
 
 	t := template.New("base.tmpl")
 	t.Funcs(template.FuncMap{
-		"url":  func(s string) string { return PrefixUrl(s, context.UrlPrefix) },
+		"url":  func(s string) string { return PrefixUrl(s, context.URLPrefix) },
 		"html": renderHTML,
 		"limitShowMeta": func(a []myradio.ShowMeta, start int, end int) []myradio.ShowMeta {
 			if len(a) < end {

--- a/utils/template.go
+++ b/utils/template.go
@@ -53,7 +53,7 @@ func RenderTemplate(w http.ResponseWriter, context structs.PageContext, data int
 
 	t := template.New("base.tmpl")
 	t.Funcs(template.FuncMap{
-		"url":  func(s string) string { return fmt.Sprintf("%s%s", context.UrlPrefix, s) },
+		"url":  func(s string) string { return PrefixUrl(s, context.UrlPrefix) },
 		"html": renderHTML,
 		"limitShowMeta": func(a []myradio.ShowMeta, start int, end int) []myradio.ShowMeta {
 			if len(a) < end {

--- a/utils/template.go
+++ b/utils/template.go
@@ -53,7 +53,7 @@ func RenderTemplate(w http.ResponseWriter, context structs.PageContext, data int
 
 	t := template.New("base.tmpl")
 	t.Funcs(template.FuncMap{
-		"url":  func(s string) string { return PrefixUrl(s, context.URLPrefix) },
+		"url":  func(s string) string { return PrefixURL(s, context.URLPrefix) },
 		"html": renderHTML,
 		"limitShowMeta": func(a []myradio.ShowMeta, start int, end int) []myradio.ShowMeta {
 			if len(a) < end {

--- a/utils/url.go
+++ b/utils/url.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PrefixUrl prefixes a URL url with prefix p.
+// If url begins with a single slash, it is treated as relative and prefixed with prefix.
+// If p does not begin with a slash and end in zero slashes, it is changed to do so.
+func PrefixUrl(url, p string) string {
+	relative := strings.HasPrefix(url, "/") && !strings.HasPrefix(url, "//")
+	if !relative {
+		return url
+	}
+
+	pt := strings.Trim(p, "/")
+	// Prevent accidentally outputting //url if prefix is empty
+	if len(pt) == 0 {
+		return url
+	}
+
+	// Because url is relative, it must already start with a slash
+	return fmt.Sprintf("/%s%s", pt, url)
+}

--- a/utils/url.go
+++ b/utils/url.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 )
 
-// PrefixUrl prefixes a URL url with prefix p.
+// PrefixURL prefixes a URL url with prefix p.
 // If url begins with a single slash, it is treated as relative and prefixed with prefix.
 // If p does not begin with a slash and end in zero slashes, it is changed to do so.
-func PrefixUrl(url, p string) string {
+func PrefixURL(url, p string) string {
 	relative := strings.HasPrefix(url, "/") && !strings.HasPrefix(url, "//")
 	if !relative {
 		return url

--- a/utils/url_test.go
+++ b/utils/url_test.go
@@ -1,61 +1,62 @@
 package utils_test
 
 import (
-	utils "github.com/UniversityRadioYork/2016-site/utils"
 	"testing"
+
+	utils "github.com/UniversityRadioYork/2016-site/utils"
 )
 
-// TestParseUrl tests whether ParseUrl works correctly.
-func TestParseUrl(t *testing.T) {
+// TestParseURL tests whether ParseURL works correctly.
+func TestParseURL(t *testing.T) {
 	cases := []struct {
 		Expected string
 		Prefix   string
-		Url      string
+		URL      string
 	}{
 		{
 			Expected: "/testsite/schedule",
 			Prefix:   "testsite",
-			Url:      "/schedule",
+			URL:      "/schedule",
 		},
 		{
 			Expected: "//schedule",
 			Prefix:   "testsite",
-			Url:      "//schedule",
+			URL:      "//schedule",
 		},
 		{
 			Expected: "schedule",
 			Prefix:   "testsite",
-			Url:      "schedule",
+			URL:      "schedule",
 		},
 		{
 			Expected: "/schedule",
 			Prefix:   "",
-			Url:      "/schedule",
+			URL:      "/schedule",
 		},
 		{
 			Expected: "//schedule",
 			Prefix:   "",
-			Url:      "//schedule",
+			URL:      "//schedule",
 		},
 		{
 			Expected: "schedule",
 			Prefix:   "",
-			Url:      "schedule",
+			URL:      "schedule",
 		},
 		{
 			Expected: "/testsite/schedule",
 			Prefix:   "/testsite",
-			Url:      "/schedule",
+			URL:      "/schedule",
 		},
 		{
 			Expected: "/testsite/schedule",
 			Prefix:   "testsite/",
-			Url:      "/schedule",
+			URL:      "/schedule",
 		},
 	}
 
 	for i, c := range cases {
-		got := utils.PrefixUrl(c.Url, c.Prefix)
+		got := utils.PrefixURL(c.URL, c.Prefix)
 		if c.Expected != got {
 			t.Errorf("case %d: expected: %s; got: %s", i+1, c.Expected, got)
 		}

--- a/utils/url_test.go
+++ b/utils/url_test.go
@@ -1,0 +1,63 @@
+package utils_test
+
+import (
+	utils "github.com/UniversityRadioYork/2016-site/utils"
+	"testing"
+)
+
+// TestParseUrl tests whether ParseUrl works correctly.
+func TestParseUrl(t *testing.T) {
+	cases := []struct {
+		Expected string
+		Prefix   string
+		Url      string
+	}{
+		{
+			Expected: "/testsite/schedule",
+			Prefix:   "testsite",
+			Url:      "/schedule",
+		},
+		{
+			Expected: "//schedule",
+			Prefix:   "testsite",
+			Url:      "//schedule",
+		},
+		{
+			Expected: "schedule",
+			Prefix:   "testsite",
+			Url:      "schedule",
+		},
+		{
+			Expected: "/schedule",
+			Prefix:   "",
+			Url:      "/schedule",
+		},
+		{
+			Expected: "//schedule",
+			Prefix:   "",
+			Url:      "//schedule",
+		},
+		{
+			Expected: "schedule",
+			Prefix:   "",
+			Url:      "schedule",
+		},
+		{
+			Expected: "/testsite/schedule",
+			Prefix:   "/testsite",
+			Url:      "/schedule",
+		},
+		{
+			Expected: "/testsite/schedule",
+			Prefix:   "testsite/",
+			Url:      "/schedule",
+		},
+	}
+
+	for i, c := range cases {
+		got := utils.PrefixUrl(c.Url, c.Prefix)
+		if c.Expected != got {
+			t.Errorf("case %d: expected: %s; got: %s", i+1, c.Expected, got)
+		}
+	}
+}

--- a/views/elements/navbar.tmpl
+++ b/views/elements/navbar.tmpl
@@ -3,19 +3,19 @@
   <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#collapsed" aria-controls="collapsed" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="/">
-    <img src="/images/logo.png" height="34" alt="{{.PageContext.LongName}} Logo" >
+  <a class="navbar-brand" href="{{url "/"}}">
+    <img src="{{url "/images/logo.png"}}" height="34" alt="{{.PageContext.LongName}} Logo" >
   </a>
   <div class="navbar-collapse collapse" id="collapsed">
     <div class="navbar-nav">
       <a class="nav-item nav-link" href="#">Schedule</a>
       <a class="nav-item nav-link" href="#">Shows</a>
       <a class="nav-item nav-link" href="#">URY Player</a>
-      <a class="nav-item nav-link" href="/about/">About Us</a>
-      <a class="nav-item nav-link" href="/getinvolved/">Get Involved</a>
-      <a class="nav-item nav-link" href="/contact/">Contact Us</a>
+      <a class="nav-item nav-link" href="{{url "/about/"}}">About Us</a>
+      <a class="nav-item nav-link" href="{{url "/getinvolved/"}}">Get Involved</a>
+      <a class="nav-item nav-link" href="{{url "/contact/"}}">Contact Us</a>
     </div>
-    <form action="/search/" class="form-inline ml-auto">
+    <form action="{{url "/search/"}}" class="form-inline ml-auto">
         <input type="text" name="term" class="form-control" placeholder="Search">
         <button type="submit" class="btn btn-outline-success" alt="Submit">Search</button>
     </form>

--- a/views/partials/base.tmpl
+++ b/views/partials/base.tmpl
@@ -8,7 +8,7 @@
     <title>{{block "title" .}}{{.PageContext.LongName}}{{end}}</title>    
 
 
-    <link rel="stylesheet" href="/css/main.scss.css" type="text/css" />
+    <link rel="stylesheet" href="{{url "/css/main.scss.css"}}" type="text/css" />
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -31,8 +31,8 @@
 
 {{template "footer" .}}
 
-<script src="/js/jquery-3.1.1.min.js"></script>
-<script src="/js/main.js"></script>
+<script src="{{url "/js/jquery-3.1.1.min.js"}}"></script>
+<script src="{{url "/js/main.js"}}"></script>
 <!-- TODO: Move to local copy of these -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>


### PR DESCRIPTION
This pull request adds a rudimentary function, and configurable, to prefix URLs emitted by 2016-site.

The reason for this change is selfish: I usually test 2016-site under a subtree on the URY testing server, and want to be able to test the whole thing with JavaScript, CSS, etc.

This adds:

* A new `utils` function, `PrefixUrl`, which takes a URL and, if it begins with exactly one slash, prefixes it with a given prefix;
* A new config option, `urlPrefix`, which controls the URL prefix to use in 2016-site.  Use `""` to disable prefixing.  (This should be optional, eventually);
* A new template function, `url`, which calls `PrefixUrl` with `urlPrefix`;
* A test set for `PrefixUrl`;
* A new `Makefile` command, `make test`, which currently just runs the single test case in `utils`;
* `{{url "…"}}` escapes for the main templates (but not yet the subpages, like `search`).

I'm not expecting this to go through into the site as-is, as it's a fairly intrusive change that needs working out before we're stuck with something we don't like.  But I thought I'd propose it anyway.