### PR TITLE
Update banners to use bootstrap4's carousel and improve current and next size

### DIFF
--- a/views/elements/banner.tmpl
+++ b/views/elements/banner.tmpl
@@ -1,22 +1,26 @@
 {{define "banner"}}
-  <div class="row banner">
-    <div id="banner-carousel" class="carousel slide" data-ride="carousel">
-      {{if gt (len .Banners) 1}}
-      <ol class="carousel-indicators">
-        {{range $index, $Banners := .Banners}}
-        <li data-target="#banner-carousel" data-slide-to="{{$index}}" class="{{ if eq $index 0 }} active {{end}}"></li>
+<div class="row banner justify-content-center">
+  <div class="col-10">
+    <div class="row">
+      <div id="banner-carousel" class="carousel slide" data-ride="carousel">
+        {{if gt (len .Banners) 1}}
+        <ol class="carousel-indicators">
+          {{range $index, $Banners := .Banners}}
+          <li data-target="#banner-carousel" data-slide-to="{{$index}}" class="{{ if eq $index 0 }} active {{end}}"></li>
+          {{end}}
+        </ol>
         {{end}}
-      </ol>
-      {{end}}
-      <div class="carousel-inner" role="listbox">
-        {{range $index, $Banners := .Banners}}
-        <div class="carousel-item {{ if eq $index 0 }} active {{end}}">
-          <a class="w-100" href="{{$Banners.Target}}">
-            <img class="d-block img-fluid" src="https://ury.org.uk{{$Banners.URL}}" alt="{{$Banners.Alt}}">
-          </a>
+        <div class="carousel-inner" role="listbox">
+          {{range $index, $Banners := .Banners}}
+          <div class="carousel-item {{ if eq $index 0 }} active {{end}}">
+            <a class="w-100" href="{{$Banners.Target}}">
+              <img class="d-block img-fluid" src="https://ury.org.uk{{$Banners.URL}}" alt="{{$Banners.Alt}}">
+            </a>
+          </div>
+          {{end}}
         </div>
-        {{end}}
       </div>
     </div>
   </div>
+</div>
 {{end}}

--- a/views/elements/banner.tmpl
+++ b/views/elements/banner.tmpl
@@ -1,25 +1,22 @@
 {{define "banner"}}
   <div class="row banner">
     <div id="banner-carousel" class="carousel slide" data-ride="carousel">
+      {{if gt (len .Banners) 1}}
+      <ol class="carousel-indicators">
+        {{range $index, $Banners := .Banners}}
+        <li data-target="#banner-carousel" data-slide-to="{{$index}}" class="{{ if eq $index 0 }} active {{end}}"></li>
+        {{end}}
+      </ol>
+      {{end}}
       <div class="carousel-inner" role="listbox">
         {{range $index, $Banners := .Banners}}
-          <div class="item {{ if eq $index 0 }} active {{end}}">
-
-            <a href="{{$Banners.Target}}">
-              <img src="https://ury.org.uk{{$Banners.URL}}" alt="{{$Banners.Alt}}">
-            </a>
-
-          </div>
+        <div class="carousel-item {{ if eq $index 0 }} active {{end}}">
+          <a class="w-100" href="{{$Banners.Target}}">
+            <img class="d-block img-fluid" src="https://ury.org.uk{{$Banners.URL}}" alt="{{$Banners.Alt}}">
+          </a>
+        </div>
         {{end}}
       </div>
-      <a class="left carousel-control" href="#banner-carousel" role="button" data-slide="prev">
-        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-        <span class="sr-only">Previous</span>
-      </a>
-      <a class="right carousel-control" href="#banner-carousel" role="button" data-slide="next">
-        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-        <span class="sr-only">Next</span>
-      </a>
     </div>
   </div>
 {{end}}

--- a/views/elements/current_and_next.tmpl
+++ b/views/elements/current_and_next.tmpl
@@ -1,28 +1,31 @@
 {{define "current_and_next"}}
-	{{with .CurrentAndNext}}
-		<div class="current-and-next row">
+{{with .CurrentAndNext}}
+<div class="current-and-next row justify-content-center">
+	<div class="col-11 col-md-10">
+		<div class="row">
 			{{if .Current}}
-				<div class="col-4 col-lg-3 col-xl-2 p-0 current-and-next-img">
-					<img src="/images/show-current.png" alt="" />
-					<a href="https://ury.org.uk/listen" class="btn btn-red listen-btn mobile-hide" title="Listen Live" onclick="window.open('http://ury.org.uk/live', 'radioplayer', 'height=665,width=380'); return false;">Listen Live</a>
-				</div>
-				<div class="col-8 col-md p-2 pt-3 px-3 p-md-3 p-lg-4 current-and-next-now">
-					<h2>Now</h2>
-					{{template "current_next" .Current}}
-				</div>
+			<div class="col-4 col-lg-2 p-0 current-and-next-img">
+				<img src="/images/show-current.png" alt="" />
+				<a href="https://ury.org.uk/listen" class="btn btn-red listen-btn mobile-hide" title="Listen Live" onclick="window.open('http://ury.org.uk/live', 'radioplayer', 'height=665,width=380'); return false;">Listen Live</a>
+			</div>
+			<div class="col-8 col-lg-5 p-2 pt-3 px-3 p-md-3 p-lg-4 current-and-next-now">
+				<h2>Now</h2>
+				{{template "current_next" .Current}}
+			</div>
 			{{end}}
 			{{if .Next}}
-				<div class="col p-3 p-lg-4 current-and-next-next">
-					<h2>Next</h2>
-					{{template "current_next" .Next}}
-				</div>
+			<div class="col col-lg-5 p-3 p-lg-4 current-and-next-next">
+				<h2>Next</h2>
+				{{template "current_next" .Next}}
+			</div>
 			{{end}}
 			<div class="col-12 mobile-only p-0">
 				<a href="https://ury.org.uk/listen" class="btn btn-lg btn-block btn-square btn-red listen-btn-mobile" title="Listen Live" onclick="window.open('http://ury.org.uk/live', 'radioplayer', 'height=665,width=380'); return false;">Listen Live</a>
 			</div>
 		</div>
-
-	{{end}}
+	</div>
+</div>
+{{end}}
 {{end}}
 
 {{define "current_next"}}

--- a/views/elements/current_and_next.tmpl
+++ b/views/elements/current_and_next.tmpl
@@ -4,7 +4,7 @@
 	<div class="col-11 col-md-10">
 		<div class="row">
 			{{if .Current}}
-			<div class="col-4 col-lg-2 p-0 current-and-next-img">
+			<div class="col-4 col-lg-3 col-xl-2 p-0 current-and-next-img">
 				<img src="/images/show-current.png" alt="" />
 				<a href="https://ury.org.uk/listen" class="btn btn-red listen-btn mobile-hide" title="Listen Live" onclick="window.open('http://ury.org.uk/live', 'radioplayer', 'height=665,width=380'); return false;">Listen Live</a>
 			</div>
@@ -14,7 +14,7 @@
 			</div>
 			{{end}}
 			{{if .Next}}
-			<div class="col col-lg-5 p-3 p-lg-4 current-and-next-next">
+			<div class="col col-lg-4 col-xl-5 p-3 p-lg-4 current-and-next-next">
 				<h2>Next</h2>
 				{{template "current_next" .Next}}
 			</div>


### PR DESCRIPTION
Banners are now displayed properly and are now slightly smaller, same goes for current and next

Wasn’t sure if we wanted the arrows (current site doesn’t have them), but I have added indicators as these are quite subtle.
![screen shot 2017-06-13 at 12 19 46](https://user-images.githubusercontent.com/10200358/27080174-a8929618-5032-11e7-8ae1-f1df9ac94d02.png)

Fixes: #58 