### PR TITLE
Add information about joining slack

### DIFF
--- a/views/getinvolved.tmpl
+++ b/views/getinvolved.tmpl
@@ -71,7 +71,7 @@
       <ul>
         <li><strong>Pay Membership - </strong>The easiest way to pay membership is through the <a href="//yusu.org/groups/university-radio-york/" target="_blank">yusu.org</a> website.</li>
         <li><strong>Sign Up To MyRadio - </strong>MyRadio is our computer system for managing shows, members, and our mailing list. You can join MyRadio by completing the form below, it’s instant and of course there’s no commitment to do anything.</li>
-        <li><strong>Join Our Slack Team - </strong>Use slack; it's like Facebook Messenger but for URY team communication. Slack has the advantage of having a “channel” for each team, so you can join any channel and see what is happening. Our Slack team: <a href="//ury.slack.com" title="Join Our Slack Team" target="_blank">ury.slack.com</a> sign up using your university email address.</li>
+        <li><strong>Join Our Slack Team - </strong>Use <a href="//slack.com/is" title="Find out more about Slack!" target="_blank">Slack</a>; it's like Facebook Messenger but for URY team communication. Slack has the advantage of having a “channel” for each team, so you can join any channel and see what is happening. Our Slack team: <a href="//ury.slack.com" title="Join Our Slack Team" target="_blank">ury.slack.com</a> sign up using your university email address.</li>
       </ul>
       <p>You can also come and <a href="{{url "/contact/"}}" title="Contact us page">visit our station</a> in Vanbrugh College, where there'll almost always be someone there to talk to you and get you set up.</p>
   </div>

--- a/views/getinvolved.tmpl
+++ b/views/getinvolved.tmpl
@@ -68,11 +68,14 @@
   <div class="container">
       <h2>How Do I Join?</h2>
       <p>If you’re ready to join URY right now, we have some very easy steps to get you started...</p>
-      <ul>
-        <li><strong>Pay Membership - </strong>The easiest way to pay membership is through the <a href="//yusu.org/groups/university-radio-york/" target="_blank">yusu.org</a> website.</li>
-        <li><strong>Sign Up To MyRadio - </strong>MyRadio is our computer system for managing shows, members, and our mailing list. You can join MyRadio by completing the form below, it’s instant and of course there’s no commitment to do anything.</li>
-        <li><strong>Join Our Slack Team - </strong>Use <a href="//slack.com/is" title="Find out more about Slack!" target="_blank">Slack</a>; it's like Facebook Messenger but for URY team communication. Slack has the advantage of having a “channel” for each team, so you can join any channel and see what is happening. Our Slack team: <a href="//ury.slack.com" title="Join Our Slack Team" target="_blank">ury.slack.com</a> sign up using your university email address.</li>
-      </ul>
+      <dl>
+        <dt>Pay Membership</dt>
+        <dd>The easiest way to pay membership is through the <a href="//yusu.org/groups/university-radio-york/" target="_blank">yusu.org</a> website.</dd>
+        <dt>Sign Up To MyRadio</dt>
+        <dd>MyRadio is our computer system for managing shows, members, and our mailing list. You can join MyRadio by completing the form below, it’s instant and of course there’s no commitment to do anything.</li>
+        <dt>Join Our Slack Team</dt>
+        <dd>Use <a href="//slack.com/is" title="Find out more about Slack!" target="_blank">Slack</a>; it's like Facebook Messenger but for URY team communication. Slack has the advantage of having a “channel” for each team, so you can join any channel and see what is happening. Our Slack team: <a href="//ury.slack.com" title="Join Our Slack Team" target="_blank">ury.slack.com</a> sign up using your university email address.</dd>
+      </dl>
       <p>You can also come and <a href="{{url "/contact/"}}" title="Contact us page">visit our station</a> in Vanbrugh College, where there'll almost always be someone there to talk to you and get you set up.</p>
   </div>
 </div>

--- a/views/getinvolved.tmpl
+++ b/views/getinvolved.tmpl
@@ -66,11 +66,14 @@
 </div>
 <div class="container-fluid container-padded  bg-third">
   <div class="container">
-    <div class="row">
       <h2>How Do I Join?</h2>
-      <p>If you're ready to sign up right now, you can fill in the form below to sign up to our mailing list and computer system. It's instant and of course there's no commitment to do anything.</p>
-      <p>You can also come and <a href="/contact/" title="Contact us page">visit our station</a> in Vanbrugh College, where there'll almost always be someone there to talk to you and get you set up.</p>
-    </div>
+      <p>If you’re ready to join URY right now, we have some very easy steps to get you started...</p>
+      <ul>
+        <li><strong>Pay Membership - </strong>The easiest way to pay membership is through the <a href="//yusu.org/groups/university-radio-york/" target="_blank">yusu.org</a> website.</li>
+        <li><strong>Sign Up To MyRadio - </strong>MyRadio is our computer system for managing shows, members, and our mailing list. You can join MyRadio by completing the form below, it’s instant and of course there’s no commitment to do anything.</li>
+        <li><strong>Join Our Slack Team - </strong>Use slack; it's like Facebook Messenger but for URY team communication. Slack has the advantage of having a “channel” for each team, so you can join any channel and see what is happening. Our Slack team: <a href="//ury.slack.com" title="Join Our Slack Team" target="_blank">ury.slack.com</a> sign up using your university email address.</li>
+      </ul>
+      <p>You can also come and <a href="{{url "/contact/"}}" title="Contact us page">visit our station</a> in Vanbrugh College, where there'll almost always be someone there to talk to you and get you set up.</p>
   </div>
 </div>
 <div class="container-fluid container-padded bg-secondary" id="signUp">


### PR DESCRIPTION
It was discussed in a committee meeting that they would like to make it clear as to why we use slack, what it is, and why new members should use it.

I think this is best suited to the get involved page. I have updated the "how to join" section to list 3 simple steps to joining URY.