### PR TITLE
disable font ligatures

### DIFF
--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -4,6 +4,7 @@ $font-family-heading: "Raleway", sans-serif;
 * {
   font-family: $font-family-body;
   font-weight: 300;
+  font-variant-ligatures: none;
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Simple one this one, I personally prefer the look of things without the ligatures:

## Before: 
![screenshot 2017-12-17 14 53 42](https://user-images.githubusercontent.com/10200358/34080700-223363fe-e33a-11e7-9e5c-2873d116d402.png)

## After:
![screenshot 2017-12-17 14 53 29](https://user-images.githubusercontent.com/10200358/34080702-2d8cf026-e33a-11e7-80ce-917f352058a8.png)


fixes: #42