### PR TITLE
Fix relative week names bug

### DIFF
--- a/utils/date.go
+++ b/utils/date.go
@@ -132,6 +132,7 @@ func IsoWeekToDate(year, week int, weekday time.Weekday) (time.Time, error) {
 }
 
 // MostRecentMonday returns the most recent Monday before d.
+// The resulting date has the same time as d.
 func MostRecentMonday(d time.Time) time.Time {
 	/* The weekday is the number of days since the most recent Sunday, so
 	   shifting it by 1 modulo 7 gives us the correct result for Monday. */
@@ -153,8 +154,9 @@ func FormatWeekRelative(start time.Time) string {
 // FormatWeekRelativeTo pretty-prints the name of the current week of start, relative to the current week of now.
 func FormatWeekRelativeTo(start, now time.Time) string {
 	// To simplify calculations, reduce start and now to their Monday.
-	startm := MostRecentMonday(start)
-	nowm := MostRecentMonday(now)
+	// Since we're going to be comparing start and now based on their date, not their time, set their timestamps equal.
+	startm := StartOfDayOn(MostRecentMonday(start))
+	nowm := StartOfDayOn(MostRecentMonday(now))
 
 	/* If we're on the same week, or the week either end of current, we can (and
 	   should) use short, human-friendly week names. */
@@ -165,13 +167,13 @@ func FormatWeekRelativeTo(start, now time.Time) string {
 	fm := nowm.AddDate(0, 0, 14)
 
 	switch {
-	case start.Before(lm):
+	case startm.Before(lm):
 		break
-	case start.Before(nowm):
+	case startm.Before(nowm):
 		return "last week"
-	case start.Before(nm):
+	case startm.Before(nm):
 		return "this week"
-	case start.Before(fm):
+	case startm.Before(fm):
 		return "next week"
 	default:
 		break

--- a/utils/date.go
+++ b/utils/date.go
@@ -147,24 +147,27 @@ func MostRecentMonday(d time.Time) time.Time {
 // FormatWeekRelative pretty-prints the name of a week starting on start, relative to today.
 // start must be a Monday.
 func FormatWeekRelative(start time.Time) string {
-	return FormatWeekRelativeTo(start, MostRecentMonday(time.Now()))
+	return FormatWeekRelativeTo(start, time.Now())
 }
 
-// FormatWeekRelativeTo pretty-prints the name of a week starting on start, relative to the week starting on now.
-// start and now must be a Monday.
+// FormatWeekRelativeTo pretty-prints the name of the current week of start, relative to the current week of now.
 func FormatWeekRelativeTo(start, now time.Time) string {
+	// To simplify calculations, reduce start and now to their Monday.
+	startm := MostRecentMonday(start)
+	nowm := MostRecentMonday(now)
+
 	/* If we're on the same week, or the week either end of current, we can (and
 	   should) use short, human-friendly week names. */
 
 	// To work out which week we're in, get the boundaries of last, this, and next week.
-	lm := now.AddDate(0, 0, -7)
-	nm := now.AddDate(0, 0, 7)
-	fm := now.AddDate(0, 0, 14)
+	lm := nowm.AddDate(0, 0, -7)
+	nm := nowm.AddDate(0, 0, 7)
+	fm := nowm.AddDate(0, 0, 14)
 
 	switch {
 	case start.Before(lm):
 		break
-	case start.Before(now):
+	case start.Before(nowm):
 		return "last week"
 	case start.Before(nm):
 		return "this week"
@@ -175,6 +178,6 @@ func FormatWeekRelativeTo(start, now time.Time) string {
 	}
 
 	// If we got here, we can't give a fancy name to this week.
-	sun := start.AddDate(0, 0, 6)
-	return start.Format("02 Jan 2006") + " to " + sun.Format("02 Jan 2006")
+	sun := startm.AddDate(0, 0, 6)
+	return startm.Format("02 Jan 2006") + " to " + sun.Format("02 Jan 2006")
 }

--- a/utils/date.go
+++ b/utils/date.go
@@ -144,22 +144,27 @@ func MostRecentMonday(d time.Time) time.Time {
 	return d.AddDate(0, 0, -dmon)
 }
 
-// FormatWeekRelative pretty-prints the name of a week starting on start.
+// FormatWeekRelative pretty-prints the name of a week starting on start, relative to today.
 // start must be a Monday.
 func FormatWeekRelative(start time.Time) string {
+	return FormatWeekRelativeTo(start, MostRecentMonday(time.Now()))
+}
+
+// FormatWeekRelativeTo pretty-prints the name of a week starting on start, relative to the week starting on now.
+// start and now must be a Monday.
+func FormatWeekRelativeTo(start, now time.Time) string {
 	/* If we're on the same week, or the week either end of current, we can (and
 	   should) use short, human-friendly week names. */
 
 	// To work out which week we're in, get the boundaries of last, this, and next week.
-	tm := MostRecentMonday(time.Now())
-	lm := tm.AddDate(0, 0, -7)
-	nm := tm.AddDate(0, 0, 7)
-	fm := tm.AddDate(0, 0, 14)
+	lm := now.AddDate(0, 0, -7)
+	nm := now.AddDate(0, 0, 7)
+	fm := now.AddDate(0, 0, 14)
 
 	switch {
 	case start.Before(lm):
 		break
-	case start.Before(tm):
+	case start.Before(now):
 		return "last week"
 	case start.Before(nm):
 		return "this week"

--- a/utils/date_test.go
+++ b/utils/date_test.go
@@ -1,0 +1,37 @@
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/UniversityRadioYork/2016-site/utils"
+)
+
+func TestFormatWeekRelativeTo_WeekStrides(t *testing.T) {
+	cases := []struct {
+		weekOffset int
+		result     string
+	}{
+		{-2, "01 Jan 2018 to 07 Jan 2018"},
+		{-1, "last week"},
+		{0, "this week"},
+		{1, "next week"},
+		{2, "29 Jan 2018 to 04 Feb 2018"},
+	}
+
+	// This should always be a Monday, and line up with the strings above.
+	now := time.Date(2018, time.January, 15, 0, 0, 0, 0, time.UTC)
+
+	for _, c := range cases {
+		start := now.AddDate(0, 0, c.weekOffset*7)
+		for i := 0; i < 7; i++ {
+			rstart := start.AddDate(0, 0, i)
+			for j := 0; j < 7; j++ {
+				rnow := now.AddDate(0, 0, j)
+				if result := utils.FormatWeekRelativeTo(rstart, rnow); result != c.result {
+					t.Errorf("mismatch: start week offset = %d, day offset = %d; reference day offset = %d; expected '%s', got '%s'", c.weekOffset, i, j, c.result, result)
+				}
+			}
+		}
+	}
+}

--- a/utils/date_test.go
+++ b/utils/date_test.go
@@ -14,13 +14,13 @@ type offset struct {
 }
 
 // buildOffsetsTable builds a table of day and hour offsets to use to test FormatWeekRelativeTo.
-// It contains the cartesian product of every day offset 0--6 and every hour offset 0--23.
+// It contains the cartesian product of every day offset 0--6 and every quarter-day offset 0, 6, 12, 18.
 func buildOffsetsTable(t *testing.T) []offset {
 	t.Helper()
 
 	offsets := []offset{}
 	for d := 0; d < 7; d++ {
-		for h := 0; h < 23; h++ {
+		for h := 0; h < 24; h += 6 {
 			offsets = append(offsets, offset{d, time.Duration(h)})
 		}
 	}


### PR DESCRIPTION
The relative week name parsing code had a few bugs in it (my fault!):

- It compared the current time, minus days elapsed since Monday, with the time of the most recent schedule.  This meant that the current hour, minute, and second were factoring into the comparison when they shouldn't have been;
- There was nothing to make sure that the formatted time was in fact a Monday.

This PRQ fixes the two, and adds a somewhat over-engineered unit test to try prevent regressions.  The test suite checks all of the cases (last week, this week, next week, before last week, after next week), then adds some day and hour offsets to the reference and queried times to try to exercise the above problems.