### PR TITLE
Made credits plural when there are multiple people in a role

### DIFF
--- a/models/show.go
+++ b/models/show.go
@@ -58,6 +58,8 @@ func (m *ShowModel) GetTimeslot(id int) (timeslot myradio.Timeslot, tracklist []
 
 	creditsToUsers, err = m.session.GetCreditsToUsers(id, true)
 
+	creditsToUsers = PluralCredits(creditsToUsers)
+
 	tracklist, err = m.session.GetTrackListForTimeslot(id)
 	return
 }

--- a/models/show.go
+++ b/models/show.go
@@ -36,8 +36,6 @@ func (m *ShowModel) GetShow(id int) (show *myradio.ShowMeta, seasons []myradio.S
 
 	creditsToUsers, err = m.session.GetCreditsToUsers(id, false)
 
-	creditsToUsers = PluralCredits(creditsToUsers)
-
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -58,8 +56,6 @@ func (m *ShowModel) GetTimeslot(id int) (timeslot myradio.Timeslot, tracklist []
 
 	creditsToUsers, err = m.session.GetCreditsToUsers(id, true)
 
-	creditsToUsers = PluralCredits(creditsToUsers)
-
 	tracklist, err = m.session.GetTrackListForTimeslot(id)
 	return
 }
@@ -75,19 +71,4 @@ func (m *ShowModel) GetSeason(id int) (season myradio.Season, timeslots []myradi
 	}
 	timeslots, err = m.session.GetTimeslotsForSeason(id)
 	return
-}
-
-// PluralCredits takes a list of credits and makes roles plural if necessary
-//
-// On success, it returns the map with pluralised role names
-func PluralCredits(dict map[string][]myradio.User) map[string][]myradio.User {
-	new_dict := make(map[string][]myradio.User)
-	for k, v := range dict {
-		if len(v) > 1 {
-			new_dict[k+"s"] = v
-		} else {
-			new_dict[k] = v
-		}
-	}
-	return new_dict
 }

--- a/models/show.go
+++ b/models/show.go
@@ -36,6 +36,8 @@ func (m *ShowModel) GetShow(id int) (show *myradio.ShowMeta, seasons []myradio.S
 
 	creditsToUsers, err = m.session.GetCreditsToUsers(id, false)
 
+	creditsToUsers = PluralCredits(creditsToUsers)
+
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -71,4 +73,19 @@ func (m *ShowModel) GetSeason(id int) (season myradio.Season, timeslots []myradi
 	}
 	timeslots, err = m.session.GetTimeslotsForSeason(id)
 	return
+}
+
+// PluralCredits takes a list of credits and makes roles plural if necessary
+//
+// On success, it returns the map with pluralised role names
+func PluralCredits(dict map[string][]myradio.User) map[string][]myradio.User {
+	new_dict := make(map[string][]myradio.User)
+	for k, v := range dict {
+		if len(v) > 1 {
+			new_dict[k+"s"] = v
+		} else {
+			new_dict[k] = v
+		}
+	}
+	return new_dict
 }

--- a/utils/template.go
+++ b/utils/template.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/UniversityRadioYork/2016-site/structs"
 	myradio "github.com/UniversityRadioYork/myradio-go"
+	"github.com/gedex/inflector"
 )
 
 // TemplatePrefix is the constant containing the filepath prefix for templates.
@@ -84,7 +85,8 @@ func RenderTemplate(w http.ResponseWriter, context structs.PageContext, data int
 			}
 			return d
 		},
-		"week": FormatWeekRelative,
+		"week":   FormatWeekRelative,
+		"plural": inflector.Pluralize,
 	})
 	t, err = t.ParseFiles(tmpls...)
 	if err != nil {

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -58,7 +58,12 @@
     <div class="row">
       {{range $key, $value := .CreditsToUsers}}
       <div class="col-sm-4 pb-3">
-        <h3>{{$key}}</h3>
+        {{$presenters := len $value}}
+        {{if gt $presenters 1}}
+          <h3>{{plural $key}}</h3>
+        {{else}}
+          <h3>{{$key}}</h3>
+        {{end}}
         {{range $value}}
         <a href="/people/{{.MemberID}}/">{{.Fname}} {{.Sname}}</a> <br>
         {{end}}

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -58,8 +58,7 @@
     <div class="row">
       {{range $key, $value := .CreditsToUsers}}
       <div class="col-sm-4 pb-3">
-        {{$presenters := len $value}}
-        {{if gt $presenters 1}}
+        {{if gt (len $value) 1}}
           <h3>{{plural $key}}</h3>
         {{else}}
           <h3>{{$key}}</h3>

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -73,7 +73,12 @@
     <div class="row">
       {{range $key, $value := .CreditsToUsers}}
       <div class="col-sm-4 pb-3">
-        <h3>{{$key}}</h3>
+        {{$presenters := len $value}}
+        {{if gt $presenters 1}}
+          <h3>{{plural $key}}</h3>
+        {{else}}
+          <h3>{{$key}}</h3>
+        {{end}}
         {{range $value}}
         <a href="/people/{{.MemberID}}/">{{.Fname}} {{.Sname}}</a> <br>
         {{end}}

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -73,8 +73,7 @@
     <div class="row">
       {{range $key, $value := .CreditsToUsers}}
       <div class="col-sm-4 pb-3">
-        {{$presenters := len $value}}
-        {{if gt $presenters 1}}
+        {{if gt (len $value) 1}}
           <h3>{{plural $key}}</h3>
         {{else}}
           <h3>{{$key}}</h3>


### PR DESCRIPTION
Fixes #90 
Seems like a band-aid fix though, as the plurals for these roles are in the database, so maybe this should be addressed in the back end API (at `/show/{id}/credits`). However, this would mean the keys would change based on the data which doesn't seem like an ideal feature of an API response. I would integrate the database plurals into this fix but the API doesn't spit them out anywhere (seems like the `scheduler/credittypes` endpoint should).

TL;DR Imma have to learn PHP to make this work _properly_ but for now I can stick an s on the end.