### PR TITLE
Basics schedule redesign

### DIFF
--- a/sass/elements/_schedule.scss
+++ b/sass/elements/_schedule.scss
@@ -1,18 +1,43 @@
 @mixin schedule-block($bg-color, $txt-color) {
-  background-color: $bg-color;
+  border-bottom: $bg-color solid 10px;
+  background: white;
+  padding: 5px;
+  margin:5px;
   a {
-    color: $txt-color;
-  } 
+    color: black;
+  }
   &:hover {
     background-color: tint($bg-color, 60%);
-  } 
+  }
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.5);
 }
-
+tr {
+  height:80px;
+}
 .schedule-blocks-sustainer {
   background-color: $secondary-color;
   color: $off-white-color;
-}
+  visibility: hidden;
 
+}
+.schedule-table {
+  border-collapse: separate;
+  table-layout: fixed;
+  border-spacing: 15px;
+
+  thead {
+    th {
+      border: none;
+    }
+  }
+  th {
+      border: none;
+  }
+  td {
+    border-top: none;
+  }
+
+}
 .schedule-blocks-regular {
   @include schedule-block($primary-color, $off-white-color);
 }

--- a/views/schedule_week.tmpl
+++ b/views/schedule_week.tmpl
@@ -9,10 +9,9 @@
 
 <!-- schedule header -->
 <div class="container-fluid bg-off-white">
-  <div class="container">
-    <div class="row">
-      <h1>Schedule <small class="muted">for {{week (index .Schedule.Dates 0)}}</small></h1>
-    </div>
+  <div class="container p-3">
+      <h1 class="display-4">Schedule</h1>
+      <h4 class="muted">for {{week (index .Schedule.Dates 0)}}</h4>
     <nav aria-label="Related Schedules" class="row nav justify-content-between">
       {{if .PrevURL}}
         <a class="nav-link" href="{{url .PrevURL.Path}}">Previous week</a>
@@ -28,42 +27,44 @@
 </div>
 
 <!-- schedule body -->
-<div class="container">
-{{with .Schedule}}
-{{if .Table}}
-<table class="table table-responsive">
-  <thead>
-    <tr>
-      <th>Time</th>
-      {{range .Dates}}
-      <th>{{.Weekday}} {{.Format "02"}}</th>
-      {{end}}
-    </tr>
-  </thead>
-  <tbody>
-    {{range .Table}}
-      <tr>
-        <th scope="row">{{.Hour | printf "%02d"}}:{{.Minute | printf "%02d"}}</th>
-        {{range .Cells}}
-          {{if ne .RowSpan 0}}
-          <td rowspan="{{.RowSpan}}" class="schedule-timeslot schedule-blocks-{{.Item.Block}}" title="{{stripHTML .Item.Desc}}">
-            {{if .Item.PageURL}}
-              <a href="{{url .Item.PageURL}}">{{.Item.Name}}</a>
-            {{else}}
-              {{.Item.Name}}
-            {{end}}
-          </td>
-          {{end}}
+<div class="container-fluid bg-off-white">
+  <div class="container">
+  {{with .Schedule}}
+  {{if .Table}}
+  <table class="table schedule-table">
+    <thead>
+      <tr style="height:50px">
+        <th width="50px">Time</th>
+        {{range .Dates}}
+        <th>{{.Weekday}} {{.Format "02"}}</th>
         {{end}}
       </tr>
-    {{end}}
-  </tbody>
-</table>
-{{else}}
-  <p>Nothing today</p>
-{{end}}
+    </thead>
+    <tbody>
+      {{range .Table}}
+        <tr>
+          <th scope="row">{{.Hour | printf "%02d"}}:{{.Minute | printf "%02d"}}</th>
+          {{range .Cells}}
+            {{if ne .RowSpan 0}}
+            <td rowspan="{{.RowSpan}}" class="schedule-timeslot schedule-blocks-{{.Item.Block}}" title="{{stripHTML .Item.Desc}}">
+              {{if .Item.PageURL}}
+                <a href="{{url .Item.PageURL}}">{{.Item.Name}}</a>
+              {{else}}
+                {{.Item.Name}}
+              {{end}}
+            </td>
+            {{end}}
+          {{end}}
+        </tr>
+      {{end}}
+    </tbody>
+  </table>
+  {{else}}
+    <p>Nothing today</p>
+  {{end}}
 
-</div><!-- /.container -->
+  </div><!-- /.container -->
+</div>
 
 {{end}}
 {{end}}


### PR DESCRIPTION
So far it looks like this:
![screenshot 2018-02-03 21 31 53](https://user-images.githubusercontent.com/10200358/35771774-0b44e616-092a-11e8-8d60-4fad45a8e9c4.png)

ideally it'll look closer to this:
![screenshot 2018-02-02 21 31 30](https://user-images.githubusercontent.com/10200358/35771803-89b5c182-092a-11e8-8315-fb7442bbc308.png)

I am going to attempt to rewrite this with divs rather than tables, to make the mobile layout a little easier. I still think having two variations of a colour is too much but I haven't removed that yet