### PR TITLE
Add links to shows and people where applicable on the awards page

### DIFF
--- a/views/about.tmpl
+++ b/views/about.tmpl
@@ -1,5 +1,4 @@
 {{define "title"}}{{.PageContext.ShortName}} | About{{end}}
-
 {{define "open-graph"}}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@{{.PageContext.MainTwitter}}">
@@ -11,7 +10,6 @@
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
 <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/about/"}}">
 {{end}}
-
 {{define "content"}}
 <div class="container-fluid banner-2">
   <div class="container container-padded">
@@ -24,96 +22,111 @@
   </div>
 </div>
 <div class="container-fluid container-padded bg-off-white">
-	<div class="container container-padded">
-    <h1 class="text-center">Welcome to URY!</h1>
+  <div class="container container-padded">
+    <h1>Welcome to URY!</h1>
     <div class="row">
       <div class="col-md-6 col-lg-4">
-        <h2>Who are URY?</h2>
+        <h3>Who are URY?</h3>
         <p>{{.PageContext.SiteDescription}}</p>
-        <p>The station is run by students for students, meaning the people behind the station understand what the listenership want to hear.</p>
-        <p>With no playlist and no set format to many of our shows, our presenters have the chance to try whatever they like, as long as it's legal!</p>
+        <p>The station is run by students for students, meaning the people behind the station understand what the listenership
+          want to hear.</p>
+        <p>With no playlist and no set format to many of our shows, our presenters have the chance to try whatever they like,
+          as long as it's legal!</p>
       </div>
       <div class="col-md-6 col-lg-4">
-        <h2>Where are URY?</h2>
+        <h3>Where are URY?</h3>
         <p>URY's studios lie at the very heart of the Campus in our own building at Vanbrugh College.</p>
-        <p>But URY's real presence is felt outside of the studio, around the campus at major University and Student Union events, whether we're covering live music, recruiting new Freshers or reporting on major news events.</p>
-        <p><a href="{{url "/contact/#map"}}" title="Contact Page">Find us on a map!</a></p>
+        <p>But URY's real presence is felt outside of the studio, around the campus at major University and Student Union events,
+          whether we're covering live music, recruiting new Freshers or reporting on major news events.</p>
+        <p>
+          <a href="{{url "/contact/#map"}}"title="Contact Page">Find us on a map!</a>
+        </p>
       </div>
       <div class="col-md-6 col-lg-4">
-        <h2>Our Teams</h2>
-        <p>Behind the scenes, the main activities involved in running the station are broken down in teams, which contain officers who are responsible for specific areas of station activity.</p>
-        <p>URY is proud to have a large active membership, and encourages people to get involved, no matter what they want to do or how much time they can commit.</p>
-        <p><a href="{{url "/teams/"}}" title="Visit the teams page">Find out more about our teams!</a></p>
+        <h3>Our Teams</h3>
+        <p>Behind the scenes, the main activities involved in running the station are broken down in teams, which contain officers
+          who are responsible for specific areas of station activity.</p>
+        <p>URY is proud to have a large active membership, and encourages people to get involved, no matter what they want to
+          do or how much time they can commit.</p>
+        <p>
+          <a href="{{url "/teams/"}}"title="Visit the teams page">Find out more about our teams!</a>
+        </p>
       </div>
     </div>
   </div>
 </div>
 <div class="container-fluid container-padded">
   <div class="container container-padded">
-      <h1>Our History</h1>
-      <div> {{/* Prevents bug where p would appear inline with h2 */}}
-        <p>URY has a rich history of pioneering broadcasting, beginning in 1968 when URY became the UK's first legal independent radio station. URY's achievements over the years include numerous awards, a launch show hosted by John Peel, special FM broadcasts and numerous charity events.</p>
-        <p>In 2005, URY obtained national recognition of its achievements by being named BBC Radio One Student Station of the Year.</p>
+    <h1>Our History</h1>
+    <div> {{/* Prevents bug where p would appear inline with h2 */}}
+      <p>URY has a rich history of pioneering broadcasting, beginning in 1968 when URY became the UK's first legal independent
+        radio station. URY's achievements over the years include numerous awards, a launch show hosted by John Peel, special
+        FM broadcasts and numerous charity events.</p>
+      <p>In 2005, URY obtained national recognition of its achievements by being named BBC Radio One Student Station of the
+        Year.</p>
     </div>
   </div>
 </div>
 <div class="container-fluid container-padded bg-primary">
   <div class="container container-padded">
-      <h1>Our Awards</h1>
-      <div> {{/* Prevents bug where p would appear inline with h2 */}}
-        <p>We are really pleased with everything we have achieved at {{.PageContext.ShortName}}, and it is really great to be recognised for this.</p>
-        <div class="row">
-          <div class="col-md-6 col-lg-6">
-            <h2>2017</h2>
-            <ul>
-              <li>Gold Best Entertainment Programme (URY:PM - with K-Spence)</li>
-              <li>Gold Best Newcomer (Will Batchelor)</li>
-              <li>Silver Best Newcomer (Matthew Stratford)</li>
-              <li>Bronze Best Technical Achievement (URY Visualisation)</li>
-            </ul>
-          </div>
-          <div class="col-md-6 col-lg-6">
-            <h2>2016</h2>
-            <ul>
-              <li>Gold Best Technical Achievement (Beat the Buzz)</li>
-              <li>Bronze Best Station Branding</li>
-              <li>Bronze Kevin Greening Award (URY: Biscuit News)</li>
-            </ul>
-          </div>
-          <div class="col-md-6 col-lg-6">
-            <h2>2015</h2>
-            <ul>
-              <li>Gold Best Entertainment Programme (URY: Harry Whittaker Show)</li>
-              <li>Gold Best Newcomer (URY: Rebecca Saw)</li>
-              <li>Silver Best Live Event or Outside Broadcast (URY: Elections Results Night)</li>
-              <li>Silver Best Technical Achievement (URY: Roses Mini OB Kits)</li>
-              <li>Bronze Best Male Presenter (URY: Harry Whittaker)</li>
-            </ul>
-          </div>
-          <div class="col-md-6 col-lg-6">
-            <h2>2014</h2>
-            <ul>
-              <li>Silver Best Journalistic Programming (URY: River Safety: York’s Rising Problem)</li>
-            </ul>
-          </div>
-          <div class="col-md-6 col-lg-6">
-            <h2>2013</h2>
-            <ul>
-              <li>Gold Best Speech Programming (URY: The New World Order: Part 2: 1651)</li>
-              <li>Silver Best Speech Programming (URY: Trimble)</li>
-              <li>Silver Best Newcomer (Harry Whittaker)</li>
-              <li>Bronze Best Entertainment Show (The Harry Whittaker Show)</li>
-            </ul>
-          </div>
-          <div class="col-md-6 col-lg-6">
-            <h2>2012</h2>
-            <ul>
-              <li>Silver Best Station</li>
-              <li>Bronze Best Specialist Music Programming (URY: Coco Electro)</li>
-            </ul>
-          </div>
-        </div>
+    <div class="row">
+      <div class="col-12">
+        <h1>Our Awards</h1>
+        <p>We are really pleased with everything we have achieved at {{.PageContext.ShortName}}, and it is really great to be
+          recognised for this.</p>
       </div>
+    </div>
+    <div class="row">
+      <div class="col-md-6 col-lg-6">
+        <h2>2017</h2>
+        <ul>
+          <li>Gold Best Entertainment Programme (<a href="{{url "/schedule/shows/13053/"}}">URY:PM - with K-Spence</a>)</li>
+          <li>Gold Best Newcomer (<a href="{{url "/people/10082/"}}">Will Batchelor</a>)</li>
+          <li>Silver Best Newcomer (<a href="{{url "/people/9858/"}}">Matthew Stratford</a>)</li>
+          <li>Bronze Best Technical Achievement (URY Visualisation)</li>
+        </ul>
+      </div>
+      <div class="col-md-6 col-lg-6">
+        <h2>2016</h2>
+        <ul>
+          <li>Gold Best Technical Achievement (Beat the Buzz)</li>
+          <li>Bronze Best Station Branding</li>
+          <li>Bronze Kevin Greening Award (<a href="{{url "/schedule/shows/13238/"}}">URY: Biscuit News</a>)</li>
+        </ul>
+      </div>
+      <div class="col-md-6 col-lg-6">
+        <h2>2015</h2>
+        <ul>
+          <li>Gold Best Entertainment Programme (<a href="{{url "/schedule/shows/12629/"}}">URY: Harry Whittaker Show</a>)</li>
+          <li>Gold Best Newcomer (<a href="{{url "/people/8897/"}}">Rebecca Saw</a>)</li>
+          <li>Silver Best Live Event or Outside Broadcast (<a href="{{url "/schedule/shows/13004/"}}">URY: Elections Results Night</a>)</li>
+          <li>Silver Best Technical Achievement (URY: Roses Mini OB Kits)</li>
+          <li>Bronze Best Male Presenter (<a href="{{url "/people/8027/"}}">Harry Whittaker</a>)</li>
+        </ul>
+      </div>
+      <div class="col-md-6 col-lg-6">
+        <h2>2014</h2>
+        <ul>
+          <li>Silver Best Journalistic Programming (<a href="{{url "/schedule/shows/12896/"}}">URY: River Safety: York’s Rising Problem</a>)</li>
+        </ul>
+      </div>
+      <div class="col-md-6 col-lg-6">
+        <h2>2013</h2>
+        <ul>
+          <li>Gold Best Speech Programming (<a href="{{url "/schedule/shows/12602/"}}">URY: The New World Order: Part 2: 1651</a>)</li>
+          <li>Silver Best Speech Programming (<a href="{{url "/podcasts/816/"}}">URY: Trimble</a>)</li>
+          <li>Silver Best Newcomer (<a href="{{url "/people/8027/"}}">Harry Whittaker</a>)</li>
+          <li>Bronze Best Entertainment Show (<a href="{{url "/schedule/shows/12629/"}}">The Harry Whittaker Show</a>)</li>
+        </ul>
+      </div>
+      <div class="col-md-6 col-lg-6">
+        <h2>2012</h2>
+        <ul>
+          <li>Silver Best Station</li>
+          <li>Bronze Best Specialist Music Programming (<a href="{{url "/schedule/shows/11183/"}}">URY: Coco Electro</a>)</li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>
 {{end}}


### PR DESCRIPTION
Also run the html through a code formatter

one of the links, URY: Trimble, is to a podcast and as podcast pages aren't merged yet it 404's