### PR TITLE
Make the search box more prominant

### DIFF
--- a/sass/base/_searchBox.scss
+++ b/sass/base/_searchBox.scss
@@ -2,9 +2,10 @@ $search-box-border: 1px solid rgba(152, 152, 152, .2);
 $search-transition-time: .5s;
 $search-button-color: #808080;
 $search-button-color-hover: #000;
+$search-background: rgb(255, 255, 255);
 
 .search-box {
-  background: $off-white-color;
+  background: $search-background;
   border: $search-box-border;
   // 10 rem can be lower but if the font is enlarged on screen it doesnt look right
   border-radius: 10em;


### PR DESCRIPTION
The search box is currently greay however so are buttons that are disabled. This is a confusing UX so I have change the search box to look less like its disabled.

## Before
![screenshot 2018-04-07 18 09 58](https://user-images.githubusercontent.com/10200358/38457939-eff5d122-3a8e-11e8-847c-1e3cf0224240.png)

## After
![screenshot 2018-04-07 18 09 47](https://user-images.githubusercontent.com/10200358/38457944-f8cc34f8-3a8e-11e8-96e7-3b4d9172f315.png)
