### PR TITLE
Suggested fix for overflowing tags

### DIFF
--- a/sass/base/_base.scss
+++ b/sass/base/_base.scss
@@ -71,3 +71,7 @@ $breakpoints: sm, md, lg, xl;
     @include make-scroll-horiz($bp);
   }
 }
+
+.overflow-hidden {
+  overflow: hidden;
+}

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -56,7 +56,7 @@
         <p>{{html .Timeslot.Description}}</p>
         <hr>
         <div class="row justify-content-between">
-          <div class="col-auto mr-auto mw-100">
+          <div class="col-auto mr-auto mw-100 overflow-hidden mb-3">
             <span class="h5 mg-right-5">Tags:</span>
             {{range .Timeslot.Tags}}
             <a href="/search?term={{.}}" alt="Search for '{{.}}'.">


### PR DESCRIPTION
This should be followed up with a limit of characters in myradio tags. This also adds some spacing between share links and tags on mobile devices. 

Closes: #125 