### PR TITLE
Add Listen Section to About Us

### DIFF
--- a/server.go
+++ b/server.go
@@ -75,6 +75,9 @@ func NewServer(c *structs.Config) (*Server, error) {
 	getRouter.HandleFunc("/uryplayer/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/ontap/", 301)
 	})
+	getRouter.HandleFunc("/listen/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/about/", 301)
+	})
 	getRouter.HandleFunc("/uryplayer/podcasts/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/podcasts/", 301)
 	})

--- a/views/about.tmpl
+++ b/views/about.tmpl
@@ -52,6 +52,44 @@
     </div>
   </div>
 </div>
+<div class="container-fluid container-padded bg-third">
+  <div class="container container-padded">
+    <h1>How To Listen?</h1>
+    <p>There are many ways you can listen to URY, whether you’re a Uni of York student, friends and family of our presenters, or you’re just interested in what our student radio has to offer.</p>
+    <div class="row">
+      <div class="col-md-6 col-lg-4">
+        <h3>On Air</h3>
+          <h5>AM Radio</h5>
+          <p>We are of course a legal radio station and we broadcast on AM radio all across campus on 1350KHz Medium Wave.</p>
+          <p>So what are you waiting for? Ask your parents if you can have their old boom box, and get it tuned into URY like it’s 1989.</p>
+          <h5>In Your Ears</h5>
+          <p>URY can occasionally be heard out and about on campus, we regularly attend campus events such as move-in days, Freshers’ Fairs, and Elections Result Night! If you hear us… come along and say hi!</p>
+      </div>
+      <div class="col-md-6 col-lg-4">
+        <h3>Online</h3>
+        <p>Left your boom box at home? Don’t worry we are online too.</p>
+          <h5>URY Website</h5>
+          <p>You can listen to us live through <a href="//ury.org.uk/live">radioplayer</a> (recommended), or via one of our streams:</p>
+          <ul>
+            <li><a target="_blank" href="//ury.org.uk/audio/live-high">High Quality (192 kb/s MPEG)</a></li>
+            <li><a target="_blank" href="//ury.org.uk/audio/live-high-ogg">High Quality OGG (128 kb/s OGG)</a></li>
+            <li><a target="_blank" href="//ury.org.uk/audio/live-mobile">Mobile Quality (48 kb/s MPEG)</a></li>
+          </ul>
+          <h5>Alexa</h5>
+          <p>We are also on TuneIn which means you can listen to us via any Alexa devices, simply say “Alexa… Play University Radio York”.</p>
+          <h5>iTunes Internet Radio</h5>
+          <p>We are available on iTunes Radio: <br>Internet Radio -> College/University -> ((URY)) - University Radio York</p>
+      </div>
+      <div class="col-md-6 col-lg-4">
+        <h3>On Tap</h3>
+        <p>URY On Tap - Refreshing content when you need it the most.</p>
+        <p>At URY we understand that you have very busy lives and can’t always tune into your favourite show live, that’s why the majority of our shows are automatically uploaded to Mixcloud, simply find the show on our schedule and listen back. <a href="{{url "/schedule/thisweek"}}">Our schedule.</a></p>
+        <p>Believe it or not but radio is also a visual medium, check out our YouTube content to see all of our latest sessions and interviews. <a href="{{url "/ontap#YouTube"}}">Our YouTube content.</a></p>
+        <p>If all of that wasn’t enough for you, we still produce the occasional podcast too! <a href="{{url "/podcasts"}}">View all podcasts!</a></p>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="container-fluid container-padded">
   <div class="container container-padded">
     <h1>Our History</h1>

--- a/views/about.tmpl
+++ b/views/about.tmpl
@@ -69,11 +69,11 @@
         <h3>Online</h3>
         <p>Left your boom box at home? Don’t worry we are online too.</p>
           <h5>URY Website</h5>
-          <p>You can listen to us live through <a href="//ury.org.uk/live">radioplayer</a> (recommended), or via one of our streams:</p>
+          <p>You can listen to us live through <a target="_blank" href="//ury.org.uk/live" title="Click to listen live.">radioplayer</a> (recommended), or via one of our streams:</p>
           <ul>
-            <li><a target="_blank" href="//ury.org.uk/audio/live-high">High Quality (192 kb/s MPEG)</a></li>
-            <li><a target="_blank" href="//ury.org.uk/audio/live-high-ogg">High Quality OGG (128 kb/s OGG)</a></li>
-            <li><a target="_blank" href="//ury.org.uk/audio/live-mobile">Mobile Quality (48 kb/s MPEG)</a></li>
+            <li><a target="_blank" href="//ury.org.uk/audio/live-high" title="Listen to URY's High Quality stream (192kb/s).">High Quality (192 kb/s MPEG)</a></li>
+            <li><a target="_blank" href="//ury.org.uk/audio/live-high-ogg" title="Listen to URY's High Quality (OGG) stream (128kb/s).">High Quality OGG (128 kb/s OGG)</a></li>
+            <li><a target="_blank" href="//ury.org.uk/audio/live-mobile" title="Listen to URY's Mobile Quality stream (48kb/s).">Mobile Quality (48 kb/s MPEG)</a></li>
           </ul>
           <h5>Alexa</h5>
           <p>We are also on TuneIn which means you can listen to us via any Alexa devices, simply say “Alexa… Play University Radio York”.</p>
@@ -83,9 +83,9 @@
       <div class="col-md-6 col-lg-4">
         <h3>On Tap</h3>
         <p>URY On Tap - Refreshing content when you need it the most.</p>
-        <p>At URY we understand that you have very busy lives and can’t always tune into your favourite show live, that’s why the majority of our shows are automatically uploaded to Mixcloud, simply find the show on our schedule and listen back. <a href="{{url "/schedule/thisweek"}}">Our schedule.</a></p>
-        <p>Believe it or not but radio is also a visual medium, check out our YouTube content to see all of our latest sessions and interviews. <a href="{{url "/ontap#YouTube"}}">Our YouTube content.</a></p>
-        <p>If all of that wasn’t enough for you, we still produce the occasional podcast too! <a href="{{url "/podcasts"}}">View all podcasts!</a></p>
+        <p>At URY we understand that you have very busy lives and can’t always tune into your favourite show live, that’s why the majority of our shows are automatically uploaded to Mixcloud, simply find the show on our schedule and listen back. <a href="{{url "/schedule/thisweek"}}" title="Click to view our schedule.">Our schedule.</a></p>
+        <p>Believe it or not but radio is also a visual medium, check out our YouTube content to see all of our latest sessions and interviews. <a href="{{url "/ontap#YouTube"}}" title="click to view our youtube content.">Our YouTube content.</a></p>
+        <p>If all of that wasn’t enough for you, we still produce the occasional podcast too! <a href="{{url "/podcasts"}}" title="Click to find all of our podcasts.">View all podcasts!</a></p>
       </div>
     </div>
   </div>

--- a/views/on_demand.tmpl
+++ b/views/on_demand.tmpl
@@ -48,7 +48,7 @@
 <div id="index-videos" class="container-fluid container-padded bg-secondary">
   <div class="row">
     <div class="col-12 col-md-8">
-      <h2>{{.PageContext.ShortName}} on Youtube</h2>
+      <a name="YouTube"></a><h2>{{.PageContext.ShortName}} on Youtube</h2>
     </div>
   </div>
   <div id="youtube-videos" class="row pb-3 youtube-grid">


### PR DESCRIPTION
In the existing site with have a page dedicated to how to listen to URY:

<img width="1063" alt="screen shot 2018-06-19 at 12 16 23" src="https://user-images.githubusercontent.com/16823823/41594237-a815541c-73ba-11e8-8762-5dc7f9c456ba.png">

I feel this is important to have on the site, but not its own page. I have added a section to the about us page showing the different ways to listen to our content.

<img width="1129" alt="screen shot 2018-06-19 at 12 17 51" src="https://user-images.githubusercontent.com/16823823/41594293-d2f0fa1a-73ba-11e8-96a3-4e455cf60194.png">
