### PR TITLE
Hide people when no show credits.

### DIFF
--- a/controllers/people.go
+++ b/controllers/people.go
@@ -34,6 +34,11 @@ func (pc *PeopleController) Get(w http.ResponseWriter, r *http.Request) {
 
 	user, officerships, credits, currentAndNext, err := pm.Get(id)
 
+	//404 when the user has no credits.
+	if len(credits) == 0 {
+		utils.RenderTemplate(w, pc.config.PageContext, err, "404.tmpl")
+		return
+	}
 	if err != nil {
 		log.Println(err)
 		utils.RenderTemplate(w, pc.config.PageContext, err, "404.tmpl")


### PR DESCRIPTION
Fixes #121 

This PR makes member pages that don't have shows 404, as to replicate 2013-site.
Podcasts already have a check to not display if they aren't published.
I'm not aware of any case where shows/timeslots would be in the DB but not be publishable.