### PR TITLE
Schedule key

### DIFF
--- a/models/schedule_item.go
+++ b/models/schedule_item.go
@@ -135,9 +135,7 @@ func getBlock(name string, StartTime time.Time) string {
 		}
 	}
 	// certain times of the day correspond to a specific show type.
-	if (StartTime.Hour() >= 21) || (StartTime.Hour() < 5) { // speacialist music
-		return "specialist-music"
-	} else if (StartTime.Hour() == 11) || (StartTime.Hour() == 19) { // missed flagship
+	if (StartTime.Hour() == 11) || (StartTime.Hour() == 19) { // missed flagship
 		return "flagship"
 	}
 	return "regular"

--- a/sass/elements/_schedule.scss
+++ b/sass/elements/_schedule.scss
@@ -5,6 +5,8 @@ $shadow: rgba(0, 0, 0, 0.5);
 
 .schedule-key-icon {
   font-size: 0.6em;
+  color: $black;
+  text-decoration: none !important; // scss-lint:disable ImportantRule
   opacity: 0.5;
 
   &:hover {

--- a/sass/elements/_schedule.scss
+++ b/sass/elements/_schedule.scss
@@ -2,6 +2,16 @@ $white: #ffffff;
 $black: #000000;
 $shadow: rgba(0, 0, 0, 0.5);
 
+
+.schedule-key-icon {
+  font-size: 0.6em;
+  opacity: 0.5;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 @mixin schedule-block($bg-color, $txt-color) {
   border-bottom: $bg-color solid 10px;
   background: $white;

--- a/views/partials/base.tmpl
+++ b/views/partials/base.tmpl
@@ -35,7 +35,7 @@
 
     <link rel="stylesheet" href="{{url "/css/main.scss.css"}}" type="text/css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,500|Roboto:300,400,500">
-    <script src="https://use.fontawesome.com/577e6fdb00.js"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
 </head>
 <body>
 {{block "header-block" .}}

--- a/views/schedule_week.tmpl
+++ b/views/schedule_week.tmpl
@@ -21,24 +21,22 @@
   <div class="container justify-content-between p-3">
     <div class="row">
       <div class="col-auto">
-        <h1 class="display-4 mobile-hide">Schedule</h1>
+        <h1 class="display-4 mobile-hide">Schedule <a class="fa fa-key schedule-key-icon" href="#key"></a></h1>
         <h5 class="text-muted mobile-hide">{{week (index .Schedule.Dates 0)}}</h5>
       </div>
-      <div class="col-auto">
+      <div class="col-12">
+        <h1 class="mobile-only inline">Schedule <a class="fa fa-key schedule-key-icon" data-toggle="collapse" data-target=".schedule-keys" aria-expanded="false" aria-controls="schedule-keys"></a></h1>
+        <h5 class="text-muted mobile-only">{{week (index .Schedule.Dates 0)}}</h5>
         <div class="schedule-keys collapse">
           <div class="key-row">
+            <span class="schedule-block-regular">Regular</span>
             <span class="schedule-block-flagship">Flagship</span>
             <span class="schedule-block-event">Events</span>
-            <span class="schedule-block-specialist-music">Specialist Music</span>
-
             <span class="schedule-block-news">News</span>
             <span class="schedule-block-speech">Speech</span>
             <span class="schedule-block-music">Music</span>
           </div>
         </div>
-          <button class="btn btn-secondary" type="button" data-toggle="collapse" data-target=".schedule-keys" aria-expanded="false" aria-controls="schedule-keys">
-          Key
-        </button>
       </div>
     </div>
 
@@ -111,7 +109,17 @@
   {{end}}
   <br>
     <div class="row justify-content-center pb-3">
-
+        <div class="schedule-keys" id="key">
+          <div class="key-row">
+            <h5 class="inline">Schedule Key:</h5>
+            <span class="schedule-block-regular">Regular</span>
+            <span class="schedule-block-flagship">Flagship</span>
+            <span class="schedule-block-event">Events</span>
+            <span class="schedule-block-news">News</span>
+            <span class="schedule-block-speech">Speech</span>
+            <span class="schedule-block-music">Music</span>
+          </div>
+        </div>
     </div>
   </div>
 </div>

--- a/views/schedule_week.tmpl
+++ b/views/schedule_week.tmpl
@@ -24,9 +24,8 @@
         <h1 class="display-4 mobile-hide">Schedule <a class="fa fa-key schedule-key-icon" href="#key"></a></h1>
         <h5 class="text-muted mobile-hide">{{week (index .Schedule.Dates 0)}}</h5>
       </div>
-      <div class="col-12">
-        <h1 class="mobile-only inline"><a class="fa fa-key schedule-key-icon" data-toggle="collapse" data-target=".schedule-keys" aria-expanded="false" aria-controls="schedule-keys"></a></h1>
-
+      <div class="col-12 mobile-only">
+        <h1 class=" inline"><a class="fa fa-key schedule-key-icon" data-toggle="collapse" data-target=".schedule-keys" aria-expanded="false" aria-controls="schedule-keys"></a></h1>
         <div class="schedule-keys collapse">
           <div class="key-row">
             <span class="schedule-block-regular">Regular</span>

--- a/views/schedule_week.tmpl
+++ b/views/schedule_week.tmpl
@@ -25,8 +25,8 @@
         <h5 class="text-muted mobile-hide">{{week (index .Schedule.Dates 0)}}</h5>
       </div>
       <div class="col-12">
-        <h1 class="mobile-only inline">Schedule <a class="fa fa-key schedule-key-icon" data-toggle="collapse" data-target=".schedule-keys" aria-expanded="false" aria-controls="schedule-keys"></a></h1>
-        <h5 class="text-muted mobile-only">{{week (index .Schedule.Dates 0)}}</h5>
+        <h1 class="mobile-only inline"><a class="fa fa-key schedule-key-icon" data-toggle="collapse" data-target=".schedule-keys" aria-expanded="false" aria-controls="schedule-keys"></a></h1>
+
         <div class="schedule-keys collapse">
           <div class="key-row">
             <span class="schedule-block-regular">Regular</span>

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -59,7 +59,7 @@
                   {{end}}
                   data-description="Checkout {{.PageData.Show.Title}} on {{.PageContext.LongName}}"
                   data-via="{{.PageContext.MainTwitter}}"
-                  class="prettySocial fa fa-twitter">
+                  class="prettySocial fab fa-twitter">
               </a>
 
               <a href="#"
@@ -70,7 +70,7 @@
                   {{if .PageData.Show.Photo}}
                       data-media="{{.PageContext.FullURL}}{{.PageData.Show.Photo}}"
                   {{end}}
-                  class="prettySocial fa fa-facebook">
+                  class="prettySocial fab fa-facebook">
               </a>
 
               <a href="#"
@@ -80,7 +80,7 @@
                   {{if .PageData.Show.Photo}}
                       data-media="{{.PageContext.FullURL}}{{.PageData.Show.Photo}}"
                   {{end}}
-                  class="prettySocial fa fa-google">
+                  class="prettySocial fab fa-google">
               </a>
 
             </div>

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -80,7 +80,7 @@
               {{end}}
               data-description="I'm listening to {{.PageData.Timeslot.Title}} ({{.PageData.Timeslot.StartTime.Format "Monday, _2 Jan 2006 - 15:04"}})"
               data-via="{{.PageContext.MainTwitter}}"
-              class="prettySocial fa fa-twitter">
+              class="prettySocial fab fa-twitter">
             </a>
 
             <a href="#"
@@ -91,7 +91,7 @@
               {{if .PageData.Timeslot.Season.ShowMeta.Photo}}
                 data-media="{{.PageContext.FullURL}}{{.PageData.Timeslot.Season.ShowMeta.Photo}}"
               {{end}}
-              class="prettySocial fa fa-facebook">
+              class="prettySocial fab fa-facebook">
             </a>
 
             <a href="#"
@@ -101,7 +101,7 @@
               {{if .PageData.Timeslot.Season.ShowMeta.Photo}}
                 data-media="{{.PageContext.FullURL}}{{.PageData.Timeslot.Season.ShowMeta.Photo}}"
               {{end}}
-              class="prettySocial fa fa-google">
+              class="prettySocial fab fa-google">
             </a>
 
           </div>


### PR DESCRIPTION
A load of schedule tweaks.

- Remove Specialist music, it doesn't make sense. At the moment it's time base, but not all shows in the time are specialist music. Neither does flagship it is possible that this would be more suited as a flag in the future rather than an entire show category. Eg a show can be a music show and a flagship. However I have left flagship for a later date.
- Move key to the bottom for desktop. 
**Reason:** Users read a page in an F shape generally, they will read across the title then down. However, in the case of having the key to the right there is suddenly a big distraction after they have read the title. Instead of going down like they are used to, they are drawn into the bright colours of the key even if you have seen it before. This takes the emphasis away from the purpose of the page and the reason that they went to the page in the first place, to see the schedule.
There is now a link in the title that when clicked takes you to the bottom of the page where the key is located this means that users that are new to the site and do not know the key are able to find it, while existing users are not distracted.
- The key remains at the top under a collapse for mobile, I believe this should be changed to match the desktop in the future when the schedule is written better for mobile.


I have also update to the latest font awesome, imo the icons look better.

closes: #141 
