### PR TITLE
Include officership history in 404 check

### DIFF
--- a/controllers/people.go
+++ b/controllers/people.go
@@ -35,7 +35,7 @@ func (pc *PeopleController) Get(w http.ResponseWriter, r *http.Request) {
 	user, officerships, credits, currentAndNext, err := pm.Get(id)
 
 	//404 when the user has no credits.
-	if len(credits) == 0 {
+	if len(credits) == 0 && len(officerships) == 0 {
 		utils.RenderTemplate(w, pc.config.PageContext, err, "404.tmpl")
 		return
 	}


### PR DESCRIPTION
Fixes an issue where someone could have an officership, but not a show, and thus when referenced on the site their page 404's