### PR TITLE
Officership date range

### DIFF
--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -80,9 +80,9 @@
             {{range .Officerships}}
               <li>
               {{- .OfficerName}} - {{if .TillDateRaw -}}
-                from {{.FromDate.Format "2006-01-02"}} to {{.TillDate.Format "2006-01-02"}}
+                from {{.FromDate.Format "_2 Jan 2006"}} to {{.TillDate.Format "_2 Jan 2006"}}
               {{- else -}}
-                since {{.FromDate.Format "2006-01-02"}}
+                since {{.FromDate.Format "_2 Jan 2006"}}
               {{- end -}}
               </li>
             {{end}}

--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -79,12 +79,11 @@
             <ul class="split-evenly-2">
             {{range .Officerships}}
               <li>
-              {{.OfficerName}} - from {{.FromDate.Format "2006-01-02"}} to
-              {{if .TillDateRaw}}
-                {{.TillDate.Format "2006-01-02"}}
-              {{else}}
-                current
-              {{end}}
+              {{- .OfficerName}} - {{if .TillDateRaw -}}
+                from {{.FromDate.Format "2006-01-02"}} to {{.TillDate.Format "2006-01-02"}}
+              {{- else -}}
+                since {{.FromDate.Format "2006-01-02"}}
+              {{- end -}}
               </li>
             {{end}}
             </ul>

--- a/views/team.tmpl
+++ b/views/team.tmpl
@@ -36,7 +36,7 @@
       <div class="container container-padded">
         <h2>Team Description</h2>
         <p>{{html .Description}}</p>
-        <h5><i class="fa fa-envelope-o"></i> <a href="mailto:{{.Alias}}@ury.org.uk" alt="Contact {{.Name}}">{{.Alias}}@ury.org.uk</a></h5>
+        <h5><i class="far fa-envelope"></i> <a href="mailto:{{.Alias}}@ury.org.uk" alt="Contact {{.Name}}">{{.Alias}}@ury.org.uk</a></h5>
       </div>
     </div>
     {{end}}


### PR DESCRIPTION
- Fixes the mail icon on the teams page.
- Changes the officership date range to say `since Date` rather than `from Date to current`
- Uses `2 Jan 2006` format 