### PR TITLE
links & theme

### DIFF
--- a/sass/base/_backgrounds.scss
+++ b/sass/base/_backgrounds.scss
@@ -8,7 +8,7 @@
   color: $white;
 
   a {
-    color: $link-blue;
+    color: $link-color-light;
   }
 }
 
@@ -17,12 +17,16 @@
   color: $black;
 
   a {
-    color: $link-blue;
+    color: $link-color-dark;
   }
 }
 
 .bg-primary {
   background: $primary-color !important;
+
+  hr {
+    border-color: $off-white-color;
+  }
 }
 
 .bg-secondary {

--- a/sass/base/_variables.scss
+++ b/sass/base/_variables.scss
@@ -15,8 +15,8 @@ $flagship: #feb93a;
 
 $disabled-color: rgb(150, 150, 150);
 $primary-color: $ury-blue-color;
-$secondary-color: tint($ury-blue-color, 80%);
-$third-color: tint($ury-blue-color, 60%);
+$secondary-color: #002040;
+$third-color: #001933;
 $off-white-color: #e1e1e1;
 
 $white: #ffffff;
@@ -24,7 +24,8 @@ $blue: #0073e6;
 $red: #d0011b;
 $black: #000000;
 
-$link-blue: #6Af;
+$link-color-light: #4cbcff;
+$link-color-dark: #0069d1;
 
 //font
 $base-font-size: 16px;

--- a/sass/elements/_navbar.scss
+++ b/sass/elements/_navbar.scss
@@ -1,4 +1,4 @@
-$nav-background: rgba(255, 255, 255, .88);
+$nav-background: rgba(255, 255, 255, .97);
 $nav-bottom-border: 1px solid rgba(2, 45, 89, .3);
 $nav-links-color: rgb(2, 45, 89);
 
@@ -6,8 +6,8 @@ $nav-links-color: rgb(2, 45, 89);
 
 
 .navbar-ury {
-  -webkit-backdrop-filter: blur(7px);
-  backdrop-filter: blur(7px);
+  -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
   background: $nav-background;
   border-bottom: $nav-bottom-border;
 

--- a/views/about.tmpl
+++ b/views/about.tmpl
@@ -52,7 +52,7 @@
     </div>
   </div>
 </div>
-<div class="container-fluid container-padded bg-third">
+<div class="container-fluid container-padded bg-primary">
   <div class="container container-padded">
     <h1>How To Listen?</h1>
     <p>There are many ways you can listen to URY, whether you’re a Uni of York student, friends and family of our presenters, or you’re just interested in what our student radio has to offer.</p>
@@ -101,7 +101,7 @@
     </div>
   </div>
 </div>
-<div class="container-fluid container-padded bg-primary">
+<div class="container-fluid container-padded bg-secondary">
   <div class="container container-padded">
     <div class="row">
       <div class="col-12">

--- a/views/getinvolved.tmpl
+++ b/views/getinvolved.tmpl
@@ -55,7 +55,7 @@
     </div>
     </div>
 </div>
-<div class="container-fluid container-padded  bg-third">
+<div class="container-fluid container-padded  bg-secondary">
   <div class="container container-padded">
       <h2>How Do I Join?</h2><br>
       <div> {{/* Prevents bug where p would appear inline with h2 */}}
@@ -72,7 +72,7 @@
       </div>
   </div>
 </div>
-<div class="container-fluid container-padded bg-secondary" id="signUp">
+<div class="container-fluid container-padded bg-third" id="signUp">
   <div class="container container-padded">
     <h1>Sign up today!</h1>
     <hr>

--- a/views/index.tmpl
+++ b/views/index.tmpl
@@ -37,13 +37,13 @@
       </div>
     </div>
   </div>
-  <div id="index-videos" class="container-fluid container-padded pb-0 bg-secondary">
+  <div id="index-videos" class="container-fluid container-padded pb-0 bg-primary">
     <h2>URY Sessions</h2>
     <div id="youtube-videos" class="row scroll-horiz pb-3 custom-scrollbar youtube-video-slider">
     </div>
   </div>
   {{if .Podcasts}}
-  <div id="index-podcasts" class="container-fluid container-padded pb-0 bg-third">
+  <div id="index-podcasts" class="container-fluid container-padded pb-0 bg-secondary">
     <div class="row">
       <div class="col-12">
         <h2>Latest Podcasts</h2>

--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -65,7 +65,7 @@
         </div>
       </div>
     </div> <!-- /outer containter -->
-    <div class="container-fluid bg-secondary">
+    <div class="container-fluid bg-primary">
       <div class="container container-padded">
         <div>
           {{if .User.Bio}}

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -91,7 +91,7 @@
 </div>
 {{with .PageData}}
 {{if .CreditsToUsers}}
-<div class="container-fluid bg-secondary">
+<div class="container-fluid bg-primary">
   <div class="container pt-3">
     <h2>Credits</h2>
     <hr>
@@ -112,7 +112,7 @@
   </div>
 </div>
 {{end}}
-<div class="container-fluid bg-third">
+<div class="container-fluid bg-secondary">
   <div class="container show-selector">
     <div class="row">
 {{end}}

--- a/views/team.tmpl
+++ b/views/team.tmpl
@@ -32,7 +32,7 @@
       </div>
     </div>
     {{if .Description}}
-    <div class="container-fluid bg-secondary">
+    <div class="container-fluid bg-primary">
       <div class="container container-padded">
         <h2>Team Description</h2>
         <p>{{html .Description}}</p>
@@ -41,7 +41,7 @@
     </div>
     {{end}}
     {{end}}
-    <div class="container-fluid bg-third">
+    <div class="container-fluid bg-secondary">
       <div class="container container-padded">
         <h2>Team Officers</h2>
         <div class="row">
@@ -57,7 +57,7 @@
         </div>
       </div>
     </div>
-    <div class="container-fluid bg-secondary">
+    <div class="container-fluid bg-third">
       <div class="container container-padded">
         <h2>Get Involved</h2>
         <p>

--- a/views/teams.tmpl
+++ b/views/teams.tmpl
@@ -23,7 +23,7 @@
       </p>
     </div>
   </div>
-  <div class="container-fluid bg-third">
+  <div class="container-fluid bg-primary">
     <div class="container container-padded">
       <div class="row">
         {{range .Teams}}

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -112,7 +112,7 @@
 </div>
 {{with .PageData}}
 {{if .CreditsToUsers}}
-<div class="container-fluid bg-secondary">
+<div class="container-fluid bg-primary">
   <div class="container pt-3">
     <h2>Credits</h2>
     <hr>
@@ -133,7 +133,7 @@
   </div>
 </div>
 {{end}}
-<div class="container-fluid bg-third">
+<div class="container-fluid bg-secondary">
   <div class="container p-3">
     <h2>Tracklist</h2>
     {{if .Tracklist}}


### PR DESCRIPTION
In an effort to improve link readability I have changed the background colours of the theme, increased consistency of theme usage and created two new link colours a light and dark one (one for dark backgrounds and one for lighter backgrounds).


New Left, Old right 
![screenshot 2018-09-22 12 24 04](https://user-images.githubusercontent.com/10200358/45916796-865bc100-be63-11e8-973d-053308703961.png)
![screenshot 2018-09-22 12 34 51](https://user-images.githubusercontent.com/10200358/45916826-ed797580-be63-11e8-9ee8-950615affa9b.png)

It's mainly the "How Do I Join" background that has changed, which both helps text readability and links. I am still not 100% happy with the contrast between background and links, but it's better than before.