### PR TITLE
Display Now when API start time is missing.

### DIFF
--- a/views/elements/current_and_next.tmpl
+++ b/views/elements/current_and_next.tmpl
@@ -55,7 +55,16 @@
 <h5 class="ellipsis">
   {{.Title}}
 </h5>
-<h6>{{.StartTime.Format "15:04"}} - {{.EndTime.Format "15:04"}}</h6>
+<h6>
+  {{if not .EndTime.IsZero}}
+    {{- if .StartTime.IsZero -}}
+      Now
+    {{- else -}}
+      {{- .StartTime.Format "15:04" -}}
+    {{- end}} -
+    {{.EndTime.Format "15:04"}}
+  {{end}}
+</h6>
 {{else}}
 <span>Looks like there is nothing coming up next yet.</span>
 {{end}}

--- a/views/elements/current_and_next.tmpl
+++ b/views/elements/current_and_next.tmpl
@@ -14,7 +14,7 @@
   </div>
   <div class="col-7 col-sm-9 col-md-5 p-0 m-0">
     {{if .Current.Url}}
-    <a class="current-and-next-now p-2 px-3 p-sm-3 p-lg-4 " href="{{.Current.Url}}" title="View the show now playing">
+    <a class="current-and-next-now p-2 px-3 p-sm-3 p-lg-4 " href="{{.Current.Url}}" title="On air now: {{.Current.Title}}">
     {{else}}
     <div class="current-and-next-now p-2 px-3 p-sm-3 p-lg-4">
     {{end}}
@@ -30,7 +30,7 @@
   {{if .Next}}
   <div class="col col-md-5 p-0 m-0">
     {{if .Next.Url}}
-    <a class="current-and-next-next p-3 p-lg-4" href="{{.Next.Url}}" title="View the show next up">
+    <a class="current-and-next-next p-3 p-lg-4" href="{{.Next.Url}}" title="On air next: {{.Next.Title}}">
     {{else}}
     <div class="current-and-next-next p-3 p-lg-4">
     {{end}}


### PR DESCRIPTION
Essentially:
- If the API doesn't give a start time (jukebox is happening), show "Now" as the start time.
- If the API doesn't give an end time (Off Air, when nothing is scheduled), hide the whole time range.

This matches the behaviour of #145.

I aim to work on showing dates for the short amount of time when term hasn't started, but there is something scheduled, since it will only display a time for a date that is +24Hrs but I think this can wait.