### PR TITLE
Allow @<domain> in signup form email

### DIFF
--- a/controllers/signup.go
+++ b/controllers/signup.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/UniversityRadioYork/2016-site/models"
 	"github.com/UniversityRadioYork/2016-site/structs"
@@ -40,13 +41,20 @@ func (gic *SignUpController) Post(w http.ResponseWriter, r *http.Request) {
 	// Check an eduroam value is submitted
 	// If not then the user is signing up using a personal email
 	if _, ok := formParams["eduroam"]; ok {
-		if formParams["eduroam"][0] == "" {
+		eduroam := formParams["eduroam"][0]
+		if eduroam == "" {
 			feedback = append(feedback, "You need to provide your York Email")
 		} else {
-			match, _ := regexp.MatchString("^[a-z]{1,6}[0-9]{1,6}$", formParams["eduroam"][0])
+			// Ignore an added @york.ac.uk (since we assume it)
+			if strings.HasSuffix(eduroam, "@york.ac.uk"){
+				eduroam = eduroam[:len(eduroam)-11]
+			}
+			log.Println(eduroam)
+			match, _ := regexp.MatchString("^[a-z]{1,6}[0-9]{1,6}$", eduroam)
 			if !match {
 				feedback = append(feedback, "The @york.ac.uk email you provided seems invalid")
 			}
+			formParams["eduroam"][0] = eduroam
 		}
 	} else {
 		if _, ok = formParams["email"]; !ok {

--- a/controllers/signup.go
+++ b/controllers/signup.go
@@ -49,7 +49,6 @@ func (gic *SignUpController) Post(w http.ResponseWriter, r *http.Request) {
 			if strings.HasSuffix(eduroam, "@york.ac.uk"){
 				eduroam = eduroam[:len(eduroam)-11]
 			}
-			log.Println(eduroam)
 			match, _ := regexp.MatchString("^[a-z]{1,6}[0-9]{1,6}$", eduroam)
 			if !match {
 				feedback = append(feedback, "The @york.ac.uk email you provided seems invalid")


### PR DESCRIPTION
Accommodate for people still typing in @york.ac.uk even though we assume it on the get involved form