### PR TITLE
Splits Show/Officerships into individual columns

### DIFF
--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -77,7 +77,7 @@
             <h2 id="shows">Shows</h2>
             <hr>
             This person has worked on the following shows:
-            <ul class="split-evenly-3">
+            <ul>
             {{range .ShowCredits}}
               <li>
                 <a href="{{.MicroSiteLink.URL}}" title="View the {{.Title}} webpage.">{{.Title}}</a>
@@ -89,7 +89,7 @@
             {{if .Officerships}}
               <h2>Officerships</h2>
               <hr>
-              <ul class="split-evenly-2">
+              <ul>
               {{range .Officerships}}
                 <li>
                 {{- .OfficerName}} - {{if .TillDateRaw -}}

--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -67,37 +67,41 @@
     </div> <!-- /outer containter -->
     <div class="container-fluid bg-primary">
       <div class="container container-padded">
-        <div>
-          {{if .User.Bio}}
-            <h2>Bio</h2>
+        {{if .User.Bio}}
+          <h2>Bio</h2>
+          <hr>
+          <p>{{html .User.Bio}}</p>
+        {{end}}
+        <div class="row">
+          <div class="col-sm">
+            <h2 id="shows">Shows</h2>
             <hr>
-            <p>{{html .User.Bio}}</p>
-          {{end}}
-          {{if .Officerships}}
-            <h2>Officerships</h2>
-            <hr>
-            <ul class="split-evenly-2">
-            {{range .Officerships}}
+            This person has worked on the following shows:
+            <ul class="split-evenly-3">
+            {{range .ShowCredits}}
               <li>
-              {{- .OfficerName}} - {{if .TillDateRaw -}}
-                from {{.FromDate.Format "_2 Jan 2006"}} to {{.TillDate.Format "_2 Jan 2006"}}
-              {{- else -}}
-                since {{.FromDate.Format "_2 Jan 2006"}}
-              {{- end -}}
+                <a href="{{.MicroSiteLink.URL}}" title="View the {{.Title}} webpage.">{{.Title}}</a>
               </li>
             {{end}}
             </ul>
-          {{end}}
-          <h2 id="shows">Shows</h2>
-          <hr>
-          This person has worked on the following shows:
-          <ul class="split-evenly-3">
-          {{range .ShowCredits}}
-            <li>
-              <a href="{{.MicroSiteLink.URL}}" title="View the {{.Title}} webpage.">{{.Title}}</a>
-            </li>
-          {{end}}
-          </ul>
+          </div>
+          <div class="col-sm">
+            {{if .Officerships}}
+              <h2>Officerships</h2>
+              <hr>
+              <ul class="split-evenly-2">
+              {{range .Officerships}}
+                <li>
+                {{- .OfficerName}} - {{if .TillDateRaw -}}
+                  from {{.FromDate.Format "_2 Jan 2006"}} to {{.TillDate.Format "_2 Jan 2006"}}
+                {{- else -}}
+                  since {{.FromDate.Format "_2 Jan 2006"}}
+                {{- end -}}
+                </li>
+              {{end}}
+              </ul>
+            {{end}}
+          </div>
         </div>
       </div>
     </div>

--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -67,11 +67,13 @@
     </div> <!-- /outer containter -->
     <div class="container-fluid bg-primary">
       <div class="container container-padded">
-        {{if .User.Bio}}
-          <h2>Bio</h2>
-          <hr>
-          <p>{{html .User.Bio}}</p>
-        {{end}}
+        <div class="row">
+          {{if .User.Bio}}
+            <h2>Bio</h2>
+            <hr>
+            <p>{{html .User.Bio}}</p>
+          {{end}}
+        </div>
         <div class="row">
           <div class="col-sm">
             <h2 id="shows">Shows</h2>


### PR DESCRIPTION
Instead of each of them being split into 2/3 rows, which had a "don't dead open inside" feel to it
Also puts Officerships below Shows, because Shows are probably more important.
Leaves bio on the top