### PR TITLE
use new css column layout to split lists

### DIFF
--- a/sass/base/_utils.scss
+++ b/sass/base/_utils.scss
@@ -1,3 +1,5 @@
+$column-gap: 30px;
+
 // Method to tint colors
 @function tint($color, $percent) {
   @return mix(white, $color, 100% - $percent);
@@ -8,39 +10,25 @@ ul {
   // Splits a list into two even columns for anything above md and three for anything above xl
   // otherwise its one column
   &.split-evenly-3 {
-    text-align: left;
-    overflow: auto;
-    width: 100%;
 
     @include media-breakpoint-up(md) {
-      li {
-        float: left;
-        width: 50%;
-        padding-right: 1em;
-      }
+      column-count: 2;
+      column-gap: $column-gap;
     }
 
     @include media-breakpoint-up(xl) {
-      li {
-        float: left;
-        width: 33%;
-      }
+      column-count: 3;
+      column-gap: $column-gap;
     }
 }
 
   // Splits a list into two even columns for anything above md
   // otherwise its one
   &.split-evenly-2 {
-    text-align: left;
-    overflow: auto;
-    width: 100%;
 
     @include media-breakpoint-up(md) {
-      li {
-        float: left;
-        width: 50%;
-        padding-right: 1em;
-      }
+      column-count: 2;
+      column-gap: $column-gap;
     }
   }
 


### PR DESCRIPTION
More like newspaper columns rather than split left right left right

p.s even if we go down this-> #167 route, this pr should still be merged as this code is used elsewhere on the site and this is a better experience.


Before:
Item 1 ..... Item 2
Item 3 ..... Item 4

After:
Item 1 ..... Item 3
Item 2 ..... Item 4