### PR TITLE
Removes transition on team cards

### DIFF
--- a/sass/base/_uryCard.scss
+++ b/sass/base/_uryCard.scss
@@ -74,8 +74,6 @@ a.ury-card,
 
 
 .team-card {
-  transition: 350ms;
-
   a.card-body  {
       color: #343a40;
 
@@ -106,9 +104,4 @@ a.ury-card,
       background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%); // scss-lint:disable ColorVariable
     }
   }
-
-  &:hover {
-    transform: scale(1.08);
-  }
-
 }


### PR DESCRIPTION
While I agree that the other cards look good with the transitions, as these cards are mostly text and we don't want them standing out like we do content, I think it's a little bit jarring to have them increase in size while you are trying to read them. Plus if overused some of the effects get boring really quickly.