### PR TITLE
Support "URY N&S" as a news & sport prefix

### DIFF
--- a/models/schedule_item.go
+++ b/models/schedule_item.go
@@ -100,6 +100,7 @@ func getBlock(name string, StartTime time.Time) string {
 		{"The Second Half With Josh Kerr", "news"},
 		{"URY SPORT", "news"},
 		{"URY News & Sport:", "news"},
+    {"URY N&S:", "news"},
 
 		{"ury speech", "speech"},
 		{"yorworld", "speech"},


### PR DESCRIPTION
Per Slack discussion - will alleviate show names running out of space in the schedule