### PR TITLE
Moving show subtypes into MyRadio, part 5 - use colour data from the API

### DIFF
--- a/controllers/schedule_week.go
+++ b/controllers/schedule_week.go
@@ -141,11 +141,19 @@ func (sc *ScheduleWeekController) makeAndRenderWeek(w http.ResponseWriter, year,
 		// Safe to continue since we can check if CaN is absent in the template
 	}
 
+	subtypes, err := sc.session.GetAllShowSubtypes()
+	if err != nil {
+		//@TODO: Do something proper here, render 404 or something
+		log.Println(err)
+		return
+	}
+
 	data := struct {
 		Schedule                  *models.WeekSchedule
 		PrevURL, CurrURL, NextURL *url.URL
 		CurrentAndNext            *myradio.CurrentAndNext
 		StartHour                 int
+		Subtypes                  []myradio.ShowSeasonSubtype
 	}{
 		Schedule:       ws,
 		PrevURL:        purl,
@@ -153,6 +161,7 @@ func (sc *ScheduleWeekController) makeAndRenderWeek(w http.ResponseWriter, year,
 		NextURL:        nurl,
 		CurrentAndNext: currentAndNext,
 		StartHour:      utils.StartHour,
+		Subtypes:       subtypes,
 	}
 
 	err = utils.RenderTemplate(w, sc.config.PageContext, data, "schedule_week.tmpl", "elements/current_and_next.tmpl")

--- a/models/schedule_item.go
+++ b/models/schedule_item.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/UniversityRadioYork/2016-site/structs"
@@ -67,85 +66,9 @@ func NewTimeslotItem(t *myradio.Timeslot, finish time.Time, u func(*myradio.Time
 		Desc:    t.Description,
 		Start:   t.StartTime,
 		Finish:  finish,
-		Block:   getBlock(t.Title, t.StartTime),
+		Block:   t.Subtype.Class,
 		PageURL: url.Path,
 	}, nil
-}
-
-func getBlock(name string, StartTime time.Time) string {
-	name = strings.ToLower(name)
-
-	type blockMatch struct {
-		nameFragment string
-		block        string
-	}
-	var blockMatches = []blockMatch{
-		{"ury: early morning", "primetime"},
-		{"ury breakfast", "primetime"},
-		{"ury lunch", "primetime"},
-		{"ury brunch", "primetime"},
-		{"URY Brunch", "primetime"},
-		{"URY Afternoon Tea:", "primetime"},
-		{"URY:PM", "primetime"},
-		{"Alumni Takeover:", "primetime"},
-
-		{"ury news", "news"},
-		{"ury sports", "news"},
-		{"ury football", "news"},
-		{"york sport report", "news"},
-		{"university radio talk", "news"},
-		{"candidate interview night", "news"},
-		{"election results night", "news"},
-		{"yusu election", "news"},
-		{"The Second Half With Josh Kerr", "news"},
-		{"URY SPORT", "news"},
-		{"URY News & Sport:", "news"},
-    {"URY N&S:", "news"},
-
-		{"ury speech", "speech"},
-		{"yorworld", "speech"},
-		{"in the stalls", "speech"},
-		{"screen", "speech"},
-		{"stage", "speech"},
-		{"game breaking", "speech"},
-		{"radio drama", "speech"},
-		{"Book Corner", "speech"},
-		{"Saturated Facts", "speech"},
-		{"URWatch", "speech"},
-		{"Society Challenge", "speech"},
-		{"Speech Showcase", "speech"},
-		{"URY Speech:", "speech"},
-
-		{"URY Music:", "music"},
-
-		{"roses live 20", "event"},
-		{"roses 20", "event"},
-    {"freshers 20", "event"},
-		{"woodstock", "event"},
-		{"movember", "event"},
-		{"panto", "event"},
-		{"101:", "event"},
-		{"Vanbrugh Chair Debate", "event"},
-		{"URY Does RAG Courtyard Takeover", "event"},
-		{"URY Presents", "event"},
-		{"URYOnTour", "event"},
-		{"URY On Tour", "event"},
-
-		{"YSTV", "collab"},
-		{"Nouse", "collab"},
-		{"York Politics Digest", "collab"},
-    {"Breakz", "collab"},
-	}
-	for _, bm := range blockMatches {
-		if strings.Contains(name, strings.ToLower(bm.nameFragment)) {
-			return bm.block
-		}
-	}
-	// certain times of the day correspond to a specific show type.
-	if (StartTime.Hour() == 11) || (StartTime.Hour() == 19) { // missed flagship
-		return "primetime"
-	}
-	return "regular"
 }
 
 // scheduleBuilder is an internal type holding information about a schedule slice under construction.

--- a/views/schedule_week.tmpl
+++ b/views/schedule_week.tmpl
@@ -36,13 +36,9 @@
         </div>
         <div class="schedule-keys collapse">
           <div class="key-row">
-            <span class="schedule-block-regular">Regular</span>
-            <span class="schedule-block-primetime">Primetime</span>
-            <span class="schedule-block-event">Events</span>
-            <span class="schedule-block-news">News</span>
-            <span class="schedule-block-speech">Speech</span>
-            <span class="schedule-block-music">Music</span>
-            <span class="schedule-block-collab">Collaboration</span>
+              {{ range .Subtypes }}
+                <span class="schedule-block-{{.Class}}">{{.Name}}</span>
+              {{end}}
           </div>
         </div>
       </div>
@@ -115,24 +111,20 @@
       </div>
     </div>
   {{end}}
+  {{end}}
   <br>
     <div class="row justify-content-center pb-3">
         <div class="schedule-keys" id="key">
           <div class="key-row">
             <h2 class="inline">Schedule Key:</h2>
-            <span class="schedule-block-regular">Regular</span>
-            <span class="schedule-block-primetime">Primetime</span>
-            <span class="schedule-block-event">Events</span>
-            <span class="schedule-block-news">News</span>
-            <span class="schedule-block-speech">Speech</span>
-            <span class="schedule-block-music">Music</span>
-            <span class="schedule-block-collab">Collaboration</span>
+            {{ range .Subtypes }}
+              <span class="schedule-block-{{.Class}}">{{.Name}}</span>
+            {{end}}
           </div>
         </div>
     </div>
   </div>
 </div>
-{{end}}
 {{end}}
 {{end}}
 {{define "footer-scripts"}}


### PR DESCRIPTION
This is a big project, comprised of several PRs. See [here](https://github.com/orgs/UniversityRadioYork/teams/officers/discussions/1) for the plan (internal only). This PR is a continuation of https://github.com/UniversityRadioYork/myradio-go/pull/48

In this PR, 2016-site uses the subtype data from MyRadio. At this point, the colours are still determined by name prefix, but now the logic is in MyRadio. This means that we can add a proper UI whenever we're ready, and 2016-site will use it from the get-go.