### PR TITLE
Open Graph and Hard Coded URLs

### DIFF
--- a/utils/template.go
+++ b/utils/template.go
@@ -56,8 +56,9 @@ func RenderTemplate(w http.ResponseWriter, context structs.PageContext, data int
 
 	t := template.New("base.tmpl")
 	t.Funcs(template.FuncMap{
-		"url":  func(s string) string { return PrefixURL(s, context.URLPrefix) },
-		"html": renderHTML,
+		"url":       func(s string) string { return PrefixURL(s, context.URLPrefix) },
+		"html":      renderHTML,
+		"stripHtml": StripHTML,
 		//Takes a splice of show meta and returns the last x elements
 		"getLastShowMeta": func(a []myradio.ShowMeta, amount int) []myradio.ShowMeta {
 			if len(a) < amount {

--- a/views/about.tmpl
+++ b/views/about.tmpl
@@ -7,8 +7,8 @@
 <meta property="og:locale" content="en_GB">
 <meta property="og:title" content="{{.PageContext.LongName}} | About Us">
 <meta property="og:description" content="{{.PageContext.SiteDescription}}">
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
-<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/about/"}}">
+<meta property="og:image" content='{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}'>
+<meta property="og:url" content='{{.PageContext.FullURL}}{{url "/about/"}}'>
 {{end}}
 {{define "content"}}
 <div class="container-fluid banner-2">

--- a/views/elements/current_and_next.tmpl
+++ b/views/elements/current_and_next.tmpl
@@ -4,13 +4,13 @@
 <div class="current-and-next row justify-content-center">
   {{if .Current}}
   <div class="col-5 col-sm-3 col-md-2 p-0 current-and-next-img">
-    <img src="
+    <img src='
     {{- if .Current.Photo -}}
       //ury.org.uk{{.Current.Photo}}
     {{- else -}}
       {{url "/images/default_show_profile.png"}}
     {{- end -}}
-    " alt="{{.Current.Title}} Logo" />
+    ' alt="{{.Current.Title}} Logo" />
   </div>
   <div class="col-7 col-sm-9 col-md-5 p-0 m-0">
     {{if .Current.Url}}

--- a/views/getinvolved.tmpl
+++ b/views/getinvolved.tmpl
@@ -7,8 +7,8 @@
 <meta property="og:type" content="website">
 <meta property="og:title" content="Want to help York make incredible award winning radio?">
 <meta property="og:description" content="Want to join one of the best, largest and most diverse societies university has to offer? Whether you to hear your voice played out on the airwaves, break the biggest news stories as they happen, play with the state-of-the-art studios and computer systems, or just plain have fun, then URY is the place for you.">
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-get_involved.jpg"}}">
-<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/getinvolved"}}">
+<meta property="og:image" content='{{.PageContext.FullURL}}{{url "/images/open_graph-get_involved.jpg"}}'>
+<meta property="og:url" content='{{.PageContext.FullURL}}{{url "/getinvolved"}}'>
 {{end}}
 
 {{define "content"}}
@@ -47,7 +47,7 @@
       <p>- If you’re keen to develop your <a href="{{url "/teams/marketing/"}}" title="Have a look at what the marketing team does!">marketing skills</a>, we have social media accounts with thousands of followers and a national award nominated brand</p>
       <p>- If you want to try out web design or <a href="{{url "/teams/computing/"}}" title="Have a look at what the computing team does!">software engineering</a>, our website and backpages are designed and run in house</p>
       <p>- Plus, if you want to <a href="{{url "/teams/news/"}}" title="Have a look at what the news and sport team does!">commentate on sport, learn to news read</a>, chat about <a href="{{url "/teams/music/"}}" title="Have a look at what the music team does!">music</a>, or wax lyrical about <a href="{{url "/teams/speech/"}}" title="Have a look at what the speech team does!">theatre, culture and the arts</a>, there’s content teams for you too!</p>
-  
+
   </div>
 </div>
 <div class="container-fluid container-padded  bg-secondary">
@@ -63,7 +63,7 @@
           <dt>Join Our Slack Team</dt>
           <dd>Use <a href="//slack.com/is" title="Find out more about Slack!" target="_blank">Slack</a>; it's like Facebook Messenger but for URY team communication. Slack has the advantage of having a “channel” for each team, so you can join any channel and see what is happening. Our Slack team: <a href="//ury.slack.com" title="Join Our Slack Team" target="_blank">ury.slack.com</a> sign up using your university email address.</dd>
         </dl>
-        <p>You can also come and <a href="{{url "/contact#map"}}" title="Contact us page">visit our station</a> in Vanbrugh College, where there'll almost always be someone there to talk to you and get you set up.</p>
+        <p>You can also come and <a href='{{url "/contact#map"}}' title="Contact us page">visit our station</a> in Vanbrugh College, where there'll almost always be someone there to talk to you and get you set up.</p>
       </div>
   </div>
 </div>
@@ -73,7 +73,7 @@
       <div> {{/* Prevents bug where p would appear inline with h2 */}}
         <p>Getting your own show or podcast is really easy! Just take a look at our <a href="/schedule" title="The URY Schedule">schedule</a>, if you can see a gap, there's no reason you couldn't fill it!</p>
         <p>Once you have completed the steps above, you will be able to sign up to training! In <a href="//ury.org.uk/myradio">MyRadio</a> head to the "Get On Air" section, then click "Get Studio Trained" and take your pick of training sessions, click join and you are good to go! If there aren't any slots available, email our Training Co-ordinator at <a href="mailto:training@ury.org.uk" title="Email our Training Co-ordinator">training@ury.org.uk</a>.</p>
-        <p>During training, we will show you how to use the studio and how to apply for a show or podcast. If you want to brainstorm ideas with our team, then head to <a href="{{url "/teams/production/"}}" title="Have a look at what the production team does!">Production</a> Meeting, which is at 8pm every Monday in V/N/123a!</p>
+        <p>During training, we will show you how to use the studio and how to apply for a show or podcast. If you want to brainstorm ideas with our team, then head to <a href='{{url "/teams/production/"}}' title="Have a look at what the production team does!">Production</a> Meeting, which is at 8pm every Monday in V/N/123a!</p>
     </div>
     </div>
 </div>

--- a/views/index.tmpl
+++ b/views/index.tmpl
@@ -69,7 +69,7 @@
       {{range .Podcasts}}
       <div class="col-8 col-sm-7 col-md-4 col-lg-3 col-xl-2 p-3 thumbnail-container">
         <a class="ury-card podcast" href="{{.MicrositeLink.URL}}">
-          <div class="ury-card-img" style="background: url('https://ury.org.uk{{.Photo}}');" title="URY Podcast: {{.Title}} Logo"></div>
+          <div class="ury-card-img" style="background: url('{{$.PageContext.FullURL}}{{.Photo}}');" title="URY Podcast: {{.Title}} Logo"></div>
           <div class="ury-card-body">
             <div class="ury-card-title">{{.Title}}</div>
             <span>{{.Time.Format "Monday, _2 Jan 2006"}}</span>

--- a/views/on_demand.tmpl
+++ b/views/on_demand.tmpl
@@ -68,7 +68,7 @@
       </div>
     {{end}}
     <div class="col-8 col-sm-7 col-md-4 col-lg-3 col-xl-2 p-3 thumbnail-container">
-      <a class="ury-card podcast link" href="{{url "/podcasts/"}}">
+      <a class="ury-card podcast link" href='{{url "/podcasts/"}}'>
         <div class="ury-card-body">
           <div class="ury-card-lg-title">See all podcasts...</div>
         </div>

--- a/views/on_demand.tmpl
+++ b/views/on_demand.tmpl
@@ -31,7 +31,7 @@
       <a class="ury-card " href="/schedule/shows/timeslots/{{.TimeslotID}}/">
         <div class="ury-card-img" style="background: url('
             {{- if .Season.ShowMeta.Photo -}}
-            https://ury.org.uk{{.Season.ShowMeta.Photo}}
+              {{$.PageContext.FullURL}}{{.Season.ShowMeta.Photo}}
             {{- else -}}
               {{url "/images/default_show_profile.png"}}
             {{- end -}}');
@@ -59,7 +59,7 @@
     {{range .PageData.LatestPodcasts}}
       <div class="col-8 col-sm-7 col-md-4 col-lg-3 col-xl-2 p-3 thumbnail-container">
         <a class="ury-card podcast" href="{{.MicrositeLink.URL}}">
-          <div class="ury-card-img" style="background: url('https://ury.org.uk{{.Photo}}');" title="URY Podcast: {{.Title}} Logo"></div>
+          <div class="ury-card-img" style="background: url('{{$.PageContext.FullURL}}{{.Photo}}');" title="URY Podcast: {{.Title}} Logo"></div>
           <div class="ury-card-body">
             <div class="ury-card-title">{{.Title}}</div>
             <span>{{.Time.Format "Monday, _2 Jan 2006"}}</span>

--- a/views/partials/base.tmpl
+++ b/views/partials/base.tmpl
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <link rel="apple-touch-icon" sizes="180x180" href="{{url "/apple-touch-icon.png"}}">
-    <link rel="icon" type="image/png" sizes="32x32" href="{{url "/favicon-32x32.png"}}">
-    <link rel="icon" type="image/png" sizes="16x16" href="{{url "/favicon-16x16.png"}}">
-    <link rel="manifest" href="{{url "/manifest.json"}}">
-    <link rel="mask-icon" href="{{url "/safari-pinned-tab.svg"}}" color="#003367">
+    <link rel="apple-touch-icon" sizes="180x180" href='{{url "/apple-touch-icon.png"}}'>
+    <link rel="icon" type="image/png" sizes="32x32" href='{{url "/favicon-32x32.png"}}'>
+    <link rel="icon" type="image/png" sizes="16x16" href='{{url "/favicon-16x16.png"}}'>
+    <link rel="manifest" href='{{url "/manifest.json"}}'>
+    <link rel="mask-icon" href='{{url "/safari-pinned-tab.svg"}}" color="#003367'>
     <meta name="theme-color" content="#003367">
 
     <title>{{block "title" .}}{{.PageContext.LongName}}{{end}}</title>
@@ -22,8 +22,8 @@
     <meta property="og:locale" content="en_GB">
     <meta property="og:title" content="{{.PageContext.LongName}}">
     <meta property="og:description" content="{{.PageContext.SiteDescription}}">
-    <meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
-    <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/"}}">
+    <meta property="og:image" content='{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}'>
+    <meta property="og:url" content='{{.PageContext.FullURL}}{{url "/"}}'>
     {{end}}
 
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
@@ -33,7 +33,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
     <!-- bootstrap end -->
 
-    <link rel="stylesheet" href="{{url "/css/main.scss.css"}}?ver={{ .PageContext.CacheBuster }}" type="text/css">
+    <link rel="stylesheet" href='{{url "/css/main.scss.css"}}?ver={{ .PageContext.CacheBuster }}' type="text/css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,500|Roboto:300,400,500">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
 </head>

--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -36,7 +36,7 @@
         <div class="row">
           <div class="col-12 col-lg-3">
             <div class="user-img profile">
-              <img class="img-fluid" src="https://ury.org.uk{{.User.Photo}}" alt="Photo of {{.User.Fname}} {{.User.Sname}}">
+              <img class="img-fluid" src="{{$.PageContext.FullURL}}{{.User.Photo}}" alt="Photo of {{.User.Fname}} {{.User.Sname}}">
             </div>
             <div class="row">
               <div class="col text-center">
@@ -51,7 +51,7 @@
               {{range getLastShowMeta .ShowCredits 6}}
                 <div class="col-4 col-md-2 p-0">
                   <a href="{{.MicroSiteLink.URL}}" title="View the {{.Title}} webpage.">
-                    <img class="img-fluid p-1" src="https://ury.org.uk{{.Photo}}" alt="{{.Title}} logo." />
+                    <img class="img-fluid p-1" src="{{$.PageContext.FullURL}}{{.Photo}}" alt="{{.Title}} logo." />
                   </a>
                 </div>
               {{end}}

--- a/views/people.tmpl
+++ b/views/people.tmpl
@@ -6,7 +6,7 @@
 <meta name="twitter:creator" content="@{{.PageContext.MainTwitter}}">
 <meta property="og:locale" content="en_GB">
 <meta property="og:title" content="{{.PageContext.ShortName}} | {{.PageData.User.Fname}} {{.PageData.User.Sname}} Profile">
-<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/people/"}}{{.PageData.User.MemberID}}">
+<meta property="og:url" content='{{.PageContext.FullURL}}{{url "/people/"}}{{.PageData.User.MemberID}}'>
 {{if.PageData.User.Bio}}
 <meta property="og:description" content="{{.PageData.User.Bio}}">
 {{else}}

--- a/views/podcast.tmpl
+++ b/views/podcast.tmpl
@@ -9,7 +9,7 @@
 {{if .PageData.Podcast.Photo}}
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Podcast.Photo}}">
 {{else}}
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "images/open_graph-general.jpg"}}">
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
 {{end}}
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}">

--- a/views/podcast.tmpl
+++ b/views/podcast.tmpl
@@ -40,13 +40,13 @@
     <div class="container container-padded">
       <div class="row">
         <div class="col-12 col-lg-3">
-          <img class="img-fluid show-img" src="
-          {{if .Podcast.Photo}}
+          <img class="img-fluid show-img" src='
+            {{if .Podcast.Photo}}
               {{$.PageContext.FullURL}}{{.Podcast.Photo}}
-          {{else}}
-            {{url "/images/default_show_profile.png"}}
-          {{end}}
-            " alt="{{.Podcast.Title}} Logo">
+            {{else}}
+              {{url "/images/default_show_profile.png"}}
+            {{end}}
+          ' alt="{{.Podcast.Title}} Logo">
         </div>
         <div class="col-12 col-lg-9">
           <h1>{{.Podcast.Title}}</h1>
@@ -68,7 +68,7 @@
               <span class="h5 mg-right-5">Share:</span>
               <a href="#"
                   data-type="twitter"
-                  data-url="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}/"
+                  data-url='{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}/'
                   {{if .PageData.Podcast.Photo}}
                       data-media="{{.PageContext.FullURL}}{{.PageData.Podcast.Photo}}"
                   {{end}}
@@ -79,7 +79,7 @@
 
               <a href="#"
                   data-type="facebook"
-                  data-url="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}/"
+                  data-url='{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}/'
                   data-title="{{.PageData.Podcast.Title}} | {{.PageContext.ShortName}}"
                   data-description="{{.PageData.Podcast.Description}}"
                   {{if .PageData.Podcast.Photo}}
@@ -107,8 +107,8 @@
   </div>
 {{end}}
 {{define "footer-scripts"}}
-<script src="{{url "/js/show.js"}}?ver={{ .PageContext.CacheBuster }}"></script>
-<script src="{{url "/js/jquery.prettySocial.min.js"}}?ver={{ .PageContext.CacheBuster }}"></script>
+<script src='{{url "/js/show.js"}}?ver={{ .PageContext.CacheBuster }}'></script>
+<script src='{{url "/js/jquery.prettySocial.min.js"}}?ver={{ .PageContext.CacheBuster }}'></script>
 <script type="text/javascript" class="source">
   $(".prettySocial").prettySocial();
 </script>

--- a/views/podcast.tmpl
+++ b/views/podcast.tmpl
@@ -42,7 +42,7 @@
         <div class="col-12 col-lg-3">
           <img class="img-fluid show-img" src="
           {{if .Podcast.Photo}}
-            https://ury.org.uk{{.Podcast.Photo}}
+              {{$.PageContext.FullURL}}{{.Podcast.Photo}}
           {{else}}
             {{url "/images/default_show_profile.png"}}
           {{end}}
@@ -109,7 +109,7 @@
       <div class="row">
         <div class="col-12 col-lg-6">
           <p>Want to put our podcast on your blog or website? Just copy the HTML code below...</p>
-          <textarea class="uryplayer-podcast-code" readonly="readonly" onclick="this.focus(); this.select();" style="border: none;" type="text" cols="30"><iframe width=&quot;500&quot; height=&quot;500&quot; src=&quot;https://ury.org.uk/podcasts/{{.PageData.Podcast.PodcastID}}/player/&quot; frameborder=&quot;0&quot; allowfullscreen > </iframe>
+          <textarea class="uryplayer-podcast-code" readonly="readonly" onclick="this.focus(); this.select();" style="border: none;" type="text" cols="30"><iframe width=&quot;500&quot; height=&quot;500&quot; src=&quot;{{$.PageContext.FullURL}}/podcasts/{{.PageData.Podcast.PodcastID}}/player/&quot; frameborder=&quot;0&quot; allowfullscreen > </iframe>
           </textarea>
         </div>
       </div>

--- a/views/podcast.tmpl
+++ b/views/podcast.tmpl
@@ -1,5 +1,20 @@
 {{define "title"}}{{.PageContext.ShortName}} | {{.PageContext.ODName}} | {{with .PageData}} {{.Podcast.Title}} {{end}} Podcast {{end}}
 
+{{define "open-graph"}}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@{{.PageContext.MainTwitter}}">
+<meta name="twitter:creator" content="@{{.PageContext.MainTwitter}}">
+<meta property="og:locale" content="en_GB">
+<meta property="og:title" content="{{.PageContext.ShortName}} | {{.PageData.Podcast.Title}}">
+{{if .PageData.Podcast.Photo}}
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Podcast.Photo}}">
+{{else}}
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url "images/open_graph-general.jpg"}}">
+{{end}}
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}">
+<meta property="og:description" content="{{ stripHtml .PageData.Podcast.Description}}">
+{{end}}
 
 {{define "content"}}
 

--- a/views/podcast.tmpl
+++ b/views/podcast.tmpl
@@ -87,16 +87,6 @@
                   {{end}}
                   class="prettySocial fab fa-facebook">
               </a>
-
-              <a href="#"
-                  data-type="googleplus"
-                  data-url="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}/"
-                  data-description="{{.PageData.Podcast.Description}}"
-                  {{if .PageData.Podcast.Photo}}
-                      data-media="{{.PageContext.FullURL}}{{.PageData.Podcast.Photo}}"
-                  {{end}}
-                  class="prettySocial fab fa-google">
-              </a>
             </div>
           </div>
         </div>

--- a/views/podcast_player.tmpl
+++ b/views/podcast_player.tmpl
@@ -3,6 +3,22 @@
 {{define "header-block"}}<!-- header -->{{end}}
 {{define "footer-block"}}<!-- footer -->{{end}}
 
+{{define "open-graph"}}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@{{.PageContext.MainTwitter}}">
+<meta name="twitter:creator" content="@{{.PageContext.MainTwitter}}">
+<meta property="og:locale" content="en_GB">
+<meta property="og:title" content="{{.PageContext.ShortName}} | {{.PageData.Podcast.Title}}">
+{{if .PageData.Podcast.Photo}}
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Podcast.Photo}}">
+{{else}}
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url "images/open_graph-general.jpg"}}">
+{{end}}
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}">
+<meta property="og:description" content="{{ stripHtml .PageData.Podcast.Description}}">
+{{end}}
+
 {{define "content"}}
 
 {{with .PageData}}

--- a/views/podcast_player.tmpl
+++ b/views/podcast_player.tmpl
@@ -25,7 +25,7 @@
   <div class="player">
     <img src="
       {{- if .Podcast.Photo -}}
-            https://ury.org.uk{{.Podcast.Photo}}
+        {{$.PageContext.FullURL}}{{.Podcast.Photo}}
       {{- else -}}
             {{url "/images/default_show_profile.png"}}
       {{- end -}}
@@ -65,10 +65,10 @@
               "name": "{{.Podcast.Title}}",
               "artist": "Artist Name",
               "album": "URY On Tap",
-              "url": "https://ury.org.uk{{.Podcast.File}}",
+              "url": "{{$.PageContext.FullURL}}{{.Podcast.File}}",
               "cover_art_url": "
                 {{- if .Podcast.Photo -}}
-                      https://ury.org.uk{{.Podcast.Photo}}
+                      {{ $.PageContext.FullURL }}{{.Podcast.Photo}}
                 {{- else -}}
                       {{url "/images/default_show_profile.png"}}
                 {{- end -}}

--- a/views/podcast_player.tmpl
+++ b/views/podcast_player.tmpl
@@ -12,10 +12,10 @@
 {{if .PageData.Podcast.Photo}}
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Podcast.Photo}}">
 {{else}}
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
+<meta property="og:image" content='{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}'>
 {{end}}
 <meta property="og:type" content="website">
-<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}">
+<meta property="og:url" content='{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}'>
 <meta property="og:description" content="{{ stripHtml .PageData.Podcast.Description}}">
 {{end}}
 
@@ -23,13 +23,13 @@
 
 {{with .PageData}}
   <div class="player">
-    <img src="
+    <img src='
       {{- if .Podcast.Photo -}}
         {{$.PageContext.FullURL}}{{.Podcast.Photo}}
       {{- else -}}
-            {{url "/images/default_show_profile.png"}}
+        {{url "/images/default_show_profile.png"}}
       {{- end -}}
-    " class="album-art"/>
+    ' class="album-art"/>
     <div class="branding">
       URY On Tap<br>
       <span>Podcast</span>
@@ -66,14 +66,14 @@
               "artist": "Artist Name",
               "album": "URY On Tap",
               "url": "{{$.PageContext.FullURL}}{{.Podcast.File}}",
-              "cover_art_url": "
+              "cover_art_url": '
                 {{- if .Podcast.Photo -}}
                       {{ $.PageContext.FullURL }}{{.Podcast.Photo}}
                 {{- else -}}
                       {{url "/images/default_show_profile.png"}}
                 {{- end -}}
-              "
-          },
+              '
+          }
       ]
   });
   /*
@@ -87,7 +87,7 @@
   });
 
 </script>
-<link rel="stylesheet" href="{{url "/css/podcast_player.css"}}">
+<link rel="stylesheet" href='{{url "/css/podcast_player.css"}}'>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:400,500">
 {{end}}
 {{end}}

--- a/views/podcast_player.tmpl
+++ b/views/podcast_player.tmpl
@@ -12,7 +12,7 @@
 {{if .PageData.Podcast.Photo}}
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Podcast.Photo}}">
 {{else}}
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "images/open_graph-general.jpg"}}">
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
 {{end}}
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/podcasts/"}}{{.PageData.Podcast.PodcastID}}">

--- a/views/podcasts.tmpl
+++ b/views/podcasts.tmpl
@@ -49,7 +49,7 @@
     <div class="mobile-hide col-12 col-md-3 col-lg-2">
       <img class="img-fluid" src="
       {{if .Photo}}
-            https://ury.org.uk{{.Photo}}
+              {{$.PageContext.FullURL}}{{.Photo}}
       {{else}}
             {{url "/images/default_show_profile.png"}}
       {{end}}

--- a/views/podcasts.tmpl
+++ b/views/podcasts.tmpl
@@ -7,7 +7,7 @@
 				<div class="row align-items-end text-center">
 					<div class="col">
 						<h1 class="display-5 header-title">
-								<a href="{{url "/ontap/"}}" title="Go back to {{.PageContext.ODName}}">
+								<a href='{{url "/ontap/"}}' title="Go back to {{.PageContext.ODName}}">
 									{{- .PageContext.ShortName }} {{.PageContext.ODName -}}
 								</a>
             </h1>
@@ -27,19 +27,19 @@
         {{if gt .PageNumber 1}}
           disabled
         {{end}}
-      " href="{{url "/podcasts/"}}page/{{.PageNumberPrev}}">&larr; Previous page</a>
+      " href='{{url "/podcasts/"}}page/{{.PageNumberPrev}}'>&larr; Previous page</a>
       <a class="nav-link
       {{if gt .PageNumber 1}}
         disabled
       {{end}}
-      " href="{{url "/podcasts/"}}">Latest</a>
+      " href='{{url "/podcasts/"}}'>Latest</a>
     </span>
     <span>
     Page {{.PageNumber}}
     </span>
     <span>
     {{if .PageNext}}
-      <a class="nav-link" href="{{url "/podcasts/"}}page/{{.PageNumberNext}}">Next page &rarr;</a>
+      <a class="nav-link" href='{{url "/podcasts/"}}page/{{.PageNumberNext}}'>Next page &rarr;</a>
     {{end}}
     </span>
   </nav>
@@ -47,14 +47,13 @@
   {{range .Podcasts}}
   <div class="row">
     <div class="mobile-hide col-12 col-md-3 col-lg-2">
-      <img class="img-fluid" src="
-      {{if .Photo}}
+      <img class="img-fluid" src='
+        {{if .Photo}}
               {{$.PageContext.FullURL}}{{.Photo}}
-      {{else}}
-            {{url "/images/default_show_profile.png"}}
-      {{end}}
-
-        " alt="{{.Title}} Logo">
+        {{else}}
+              {{url "/images/default_show_profile.png"}}
+        {{end}}
+      ' alt="{{.Title}} Logo">
     </div>
     <div class="col-12 col-md-9 col-lg-10">
       <h4>

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -9,10 +9,10 @@
 {{if .PageData.Show.Photo}}
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Show.Photo}}">
 {{else}}
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
+<meta property="og:image" content='{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}'>
 {{end}}
 <meta property="og:type" content="website">
-<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/schedule/shows/"}}{{.PageData.Show.ShowID}}">
+<meta property="og:url" content='{{.PageContext.FullURL}}{{url "/schedule/shows/"}}{{.PageData.Show.ShowID}}'>
 <meta property="og:description" content="{{ stripHtml .PageData.Show.Description}}">
 {{end}}
 
@@ -25,12 +25,12 @@
   <div class="container p-3">
     <div class="row">
       <div class="col-12 col-sm-5 col-lg-3">
-        <img class="img-fluid show-img" src="
+        <img class="img-fluid show-img" src='
         {{- if .Show.Photo -}}
           {{$.PageContext.FullURL}}{{.Show.Photo}}
         {{- else -}}
-        {{url "/images/default_show_profile.png"}}
-        {{- end -}}"
+          {{url "/images/default_show_profile.png"}}
+        {{- end -}}'
         alt="{{.Show.Title}} Logo">
         <div class="row">
           <div class="col-6 text-center">
@@ -196,8 +196,8 @@
 <script src="//cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
 <script src="//cdn.datatables.net/1.10.18/js/dataTables.bootstrap4.min.js"></script>
 <script src="//cdn.datatables.net/plug-ins/1.10.16/api/fnFindCellRowIndexes.js"></script>
-<script src="{{url "/js/show.js"}}?ver={{ .PageContext.CacheBuster }}"></script>
-<script src="{{url "/js/jquery.prettySocial.min.js"}}?ver={{ .PageContext.CacheBuster }}"></script>
+<script src='{{url "/js/show.js"}}?ver={{ .PageContext.CacheBuster }}'></script>
+<script src='{{url "/js/jquery.prettySocial.min.js"}}?ver={{ .PageContext.CacheBuster }}'></script>
 <script type="text/javascript" class="source">
   $(".prettySocial").prettySocial();
 </script>

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -27,7 +27,7 @@
       <div class="col-12 col-sm-5 col-lg-3">
         <img class="img-fluid show-img" src="
         {{- if .Show.Photo -}}
-        https://ury.org.uk{{.Show.Photo}}
+          {{$.PageContext.FullURL}}{{.Show.Photo}}
         {{- else -}}
         {{url "/images/default_show_profile.png"}}
         {{- end -}}"

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -9,7 +9,7 @@
 {{if .PageData.Show.Photo}}
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Show.Photo}}">
 {{else}}
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "images/open_graph-general.jpg"}}">
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
 {{end}}
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/schedule/shows/"}}{{.PageData.Show.ShowID}}">

--- a/views/show.tmpl
+++ b/views/show.tmpl
@@ -13,7 +13,7 @@
 {{end}}
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/schedule/shows/"}}{{.PageData.Show.ShowID}}">
-<meta property="og:description" content="{{.PageData.Show.Description}}">
+<meta property="og:description" content="{{ stripHtml .PageData.Show.Description}}">
 {{end}}
 
 {{define "content"}}

--- a/views/team.tmpl
+++ b/views/team.tmpl
@@ -6,9 +6,9 @@
 <meta name="twitter:creator" content="@{{.PageContext.MainTwitter}}">
 <meta property="og:locale" content="en_GB">
 <meta property="og:title" content="{{.PageContext.ShortName}} | Teams | {{.PageData.Team.Name}}">
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
+<meta property="og:image" content='{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}'>
 <meta property="og:type" content="website">
-<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/teams/"}}{{.PageData.Team.Alias}}">
+<meta property="og:url" content='{{.PageContext.FullURL}}{{url "/teams/"}}{{.PageData.Team.Alias}}'>
 <meta property="og:description" content="{{ stripHtml .PageData.Team.Description}}">
 {{end}}
 
@@ -30,10 +30,10 @@
       <div class="container container-padded">
         <div class="row justify-content-center">
           <div class="text-center">
-            <h1 class="display-5"><a href="{{url "/teams/"}}" title="View all teams">Our Teams</a></h1>
+            <h1 class="display-5"><a href='{{url "/teams/"}}' title="View all teams">Our Teams</a></h1>
             <h2 class="display-5">The people who make URY happen!</h2>
             <br>
-            <a href="{{url "/getinvolved/#signUp"}}" class="btn btn-primary-inverse btn-lg">Be part of one!</a>
+            <a href='{{url "/getinvolved/#signUp"}}' class="btn btn-primary-inverse btn-lg">Be part of one!</a>
           </div>
         </div>
       </div>
@@ -74,9 +74,9 @@
       <div class="container container-padded">
         <h2>Get Involved</h2>
         <p>
-         If you have any further questions, please contact the team officers by using the email seen above. You can also come and visit our station in Vanbrugh College, where there'll almost always be someone there to talk to you and will help you to join the team.
+          If you have any further questions, please contact the team officers by using the email seen above. You can also come and visit our station in Vanbrugh College, where there'll almost always be someone there to talk to you and will help you to join the team.
         </p>
-        <a href="{{url "/getinvolved/"}}" class="btn btn-primary-inverse btn-md">Sign up for URY!</a>
+        <a href='{{url "/getinvolved/"}}' class="btn btn-primary-inverse btn-md">Sign up for URY!</a>
       </div>
     </div>
   {{end}}

--- a/views/team.tmpl
+++ b/views/team.tmpl
@@ -1,4 +1,17 @@
 {{define "title"}}{{.PageContext.ShortName}} | {{with .PageData.Team}}{{.Name}}{{end}}{{end}}
+
+{{define "open-graph"}}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@{{.PageContext.MainTwitter}}">
+<meta name="twitter:creator" content="@{{.PageContext.MainTwitter}}">
+<meta property="og:locale" content="en_GB">
+<meta property="og:title" content="{{.PageContext.ShortName}} | Teams | {{.PageData.Team.Name}}">
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/teams/"}}{{.PageData.Team.Alias}}">
+<meta property="og:description" content="{{ stripHtml .PageData.Team.Description}}">
+{{end}}
+
 {{define "officer"}}
 <div class="col-12 col-sm-6 col-md-3 col-lg-2">
   <a href="/people/{{.User.MemberID}}" title="Goto {{.User.Fname}} {{.User.Sname}}'s profile">

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -60,7 +60,7 @@
       <div class="col-12 col-sm-5 col-lg-3">
         <img class="img-fluid show-img" src="
         {{if .Timeslot.Season.ShowMeta.Photo}}
-        https://ury.org.uk{{.Timeslot.Season.ShowMeta.Photo}}
+            {{$.PageContext.FullURL}}{{.Timeslot.Season.ShowMeta.Photo}}
         {{else}}
         {{url "/images/default_show_profile.png"}}
         {{end}}"

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -9,7 +9,7 @@
 {{if .PageData.Timeslot.Season.ShowMeta.Photo}}
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Timeslot.Season.ShowMeta.Photo}}">
 {{else}}
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "images/open_graph-general.jpg"}}">
+<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
 {{end}}
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/shows/timeslots/"}}{{.PageData.Timeslot.TimeslotID}}">

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -13,7 +13,7 @@
 {{end}}
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{.PageContext.FullURL}}{{url "/shows/timeslots/"}}{{.PageData.Timeslot.TimeslotID}}">
-<meta property="og:description" content="{{.PageData.Timeslot.Description}}">
+<meta property="og:description" content="{{ stripHtml .PageData.Timeslot.Description}}">
 {{end}}
 
 {{define "content"}}

--- a/views/timeslot.tmpl
+++ b/views/timeslot.tmpl
@@ -5,14 +5,14 @@
 <meta name="twitter:site" content="@{{.PageContext.MainTwitter}}">
 <meta name="twitter:creator" content="@{{.PageContext.MainTwitter}}">
 <meta property="og:locale" content="en_GB">
-<meta property="og:title" content="{{.PageContext.ShortName}} | {{.PageData.Timeslot.Title}} {{.PageData.Timeslot.StartTime.Format "Monday, _2 Jan 2006 - 15:04"}}">
+<meta property="og:title" content='{{.PageContext.ShortName}} | {{.PageData.Timeslot.Title}} {{.PageData.Timeslot.StartTime.Format "Monday, _2 Jan 2006 - 15:04"}}'>
 {{if .PageData.Timeslot.Season.ShowMeta.Photo}}
 <meta property="og:image" content="{{.PageContext.FullURL}}{{url .PageData.Timeslot.Season.ShowMeta.Photo}}">
 {{else}}
-<meta property="og:image" content="{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}">
+<meta property="og:image" content='{{.PageContext.FullURL}}{{url "/images/open_graph-general.jpg"}}'>
 {{end}}
 <meta property="og:type" content="website">
-<meta property="og:url" content="{{.PageContext.FullURL}}{{url "/shows/timeslots/"}}{{.PageData.Timeslot.TimeslotID}}">
+<meta property="og:url" content='{{.PageContext.FullURL}}{{url "/shows/timeslots/"}}{{.PageData.Timeslot.TimeslotID}}'>
 <meta property="og:description" content="{{ stripHtml .PageData.Timeslot.Description}}">
 {{end}}
 
@@ -58,12 +58,12 @@
   <div class="container p-3">
     <div class="row">
       <div class="col-12 col-sm-5 col-lg-3">
-        <img class="img-fluid show-img" src="
-        {{if .Timeslot.Season.ShowMeta.Photo}}
+        <img class="img-fluid show-img" src='
+          {{if .Timeslot.Season.ShowMeta.Photo}}
             {{$.PageContext.FullURL}}{{.Timeslot.Season.ShowMeta.Photo}}
-        {{else}}
-        {{url "/images/default_show_profile.png"}}
-        {{end}}"
+          {{else}}
+            {{url "/images/default_show_profile.png"}}
+          {{end}}'
         alt="{{.Timeslot.Title}} Logo">
         <div class="row">
           <div class="col text-center">


### PR DESCRIPTION
- Podcasts/Teams were missing open graph stuff.
- Shows/episodes had html in the description tags.
- Fixed a tonne of hardcoded ury.org.uk with the .fullURL parameter (as far as I can tell I've tested that all of these work fine, i've missed a couple out because they're inside sub-blocks without access to .PageContext :/)
- Replaced double-quotes for single ones in HTML (is valid afaict) such that we don't nest double quotes and confuse syntax highlighting.
