### PR TITLE
footer stays at the bottom of the page

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -386,3 +386,14 @@ footer {
     height: auto;
   }
 }
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.mainPageGrowingSpacer{
+  flex-grow: 1;
+  background-color: $off-white-color;
+}

--- a/views/partials/base.tmpl
+++ b/views/partials/base.tmpl
@@ -52,6 +52,7 @@
 
 
 {{block "footer-block" .}}
+    <div class="mainPageGrowingSpacer"></div>
     {{template "footer" .}}
 {{end}}
 <script>var MyRadioAPIKey = {{.PageContext.MyRadioAPIKey }};</script>


### PR DESCRIPTION
fixes the issue where there's whitespace under the footer on some screen sizes (examples below)

https://ury.org.uk/podcasts/1293/
https://ury.org.uk/teams/management/