### PR TITLE
Add a list of music blog articles

### DIFF
--- a/controllers/music.go
+++ b/controllers/music.go
@@ -45,6 +45,8 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
   if err != nil {
     fmt.Printf("Failed to query URL: %v\n", err)
     isError = true
+    RenderError(w, sc)
+    return
   }
   defer resp.Body.Close()
 
@@ -89,11 +91,8 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
 
   // If there was an error, render the error page
   if isError {
-    err = utils.RenderTemplate(w, sc.config.PageContext, nil, "404.tmpl")
-    if err != nil {
-      log.Println(err)
-      return
-    }
+    RenderError(w, sc)
+    return
   }
 
 	err = utils.RenderTemplate(w, sc.config.PageContext, rss.Channel.Items, "music.tmpl")
@@ -101,4 +100,12 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
+}
+
+func RenderError(w http.ResponseWriter, sc *MusicController) {
+  var err = utils.RenderTemplate(w, sc.config.PageContext, nil, "404.tmpl")
+  if err != nil {
+    log.Println(err)
+    return
+  }
 }

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -77,6 +77,16 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
     }
   }
 
+  // format the date of each post to be more readable
+  for i := range rss.Channel.Items {
+    var text string
+    var layout string = "Mon, 02 Jan 2006 15:04:05 MST"
+    text, err = utils.FormatRSSDate(rss.Channel.Items[i].PubDate, layout)
+    if err == nil {
+      rss.Channel.Items[i].PubDate = text
+    }
+  }
+
   // If there was an error, render the error page
   if isError {
     err = utils.RenderTemplate(w, sc.config.PageContext, nil, "404.tmpl")

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -1,0 +1,103 @@
+package controllers
+
+import (
+	"log"
+	"net/http"
+  "encoding/xml"
+	"fmt"
+	"io/ioutil"
+  "regexp"
+
+	"github.com/UniversityRadioYork/2016-site/structs"
+	"github.com/UniversityRadioYork/2016-site/utils"
+	"github.com/UniversityRadioYork/myradio-go"
+)
+
+// MusicController is the controller for the Music page.
+type MusicController struct {
+	Controller
+}
+
+// Post represents an individual post in the RSS feed
+type Post struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+  PubDate     string `xml:"pubDate"`
+  Updated     string `xml:"updated"`
+  Content     string `xml:"encoded"`
+}
+
+// NewMusicController returns a new MusicController with the MyRadio session s
+// and configuration context c.
+func NewMusicController(s *myradio.Session, c *structs.Config) *MusicController {
+	return &MusicController{Controller{session: s, config: c}}
+}
+
+// Get handles the HTTP GET request r for the Music page, writing to w.
+func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
+  // URL of the RSS feed to query
+  url := "https://medium.com/feed/@urymusic"
+
+  isError := false
+
+  // Make HTTP GET request
+  resp, err := http.Get(url)
+  if err != nil {
+    fmt.Printf("Failed to query URL: %v\n", err)
+    isError = true
+  }
+  defer resp.Body.Close()
+
+  // Read the response body
+  xmlData, err := ioutil.ReadAll(resp.Body)
+  if err != nil {
+    fmt.Printf("Failed to read response body: %v\n", err)
+    isError = true
+  }
+
+  // Parse the XML data into a struct
+  var rss struct {
+    Channel struct {
+      Items []Post `xml:"item"`
+    } `xml:"channel"`
+  }
+
+  err = xml.Unmarshal(xmlData, &rss)
+  if err != nil {
+    fmt.Printf("Failed to parse XML: %v\n", err)
+    isError = true
+  }
+
+  // set content of each post to to scrape the first <em> tag
+  for i := range rss.Channel.Items {
+    var text string
+    text, err = ExtractFirstEmTagContent(string(rss.Channel.Items[i].Content))
+    if err == nil {
+      rss.Channel.Items[i].Content = text
+    }
+  }
+
+  // If there was an error, render the error page
+  if isError {
+    err = utils.RenderTemplate(w, sc.config.PageContext, nil, "404.tmpl")
+    if err != nil {
+      log.Println(err)
+      return
+    }
+  }
+
+	err = utils.RenderTemplate(w, sc.config.PageContext, rss.Channel.Items, "music.tmpl")
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}
+
+func ExtractFirstEmTagContent(htmlStr string) (string, error) {
+	re := regexp.MustCompile(`(?i)<em>(.*?)</em>`)
+	match := re.FindStringSubmatch(htmlStr)
+	if len(match) == 2 {
+		return match[1], nil
+	}
+	return "", fmt.Errorf("no <em> tag found")
+}

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -6,6 +6,7 @@ import (
   "encoding/xml"
 	"fmt"
 	"io/ioutil"
+  "html"
 
 	"github.com/UniversityRadioYork/2016-site/structs"
 	"github.com/UniversityRadioYork/2016-site/utils"
@@ -72,7 +73,7 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
     var text string
     text, err = utils.ExtractFirstEmTagContent(string(rss.Channel.Items[i].Content))
     if err == nil {
-      rss.Channel.Items[i].Content = text
+      rss.Channel.Items[i].Content = html.EscapeString(text)
     }
   }
 

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
   "encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
   "html"
 
 	"github.com/UniversityRadioYork/2016-site/structs"
@@ -49,7 +49,7 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
   defer resp.Body.Close()
 
   // Read the response body
-  xmlData, err := ioutil.ReadAll(resp.Body)
+  xmlData, err := io.ReadAll(resp.Body)
   if err != nil {
     fmt.Printf("Failed to read response body: %v\n", err)
     isError = true

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -102,7 +102,7 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func RenderError(w http.ResponseWriter, sc *MusicController) {
-  var err = utils.RenderTemplate(w, sc.config.PageContext, nil, "404.tmpl")
+  err := utils.RenderTemplate(w, sc.config.PageContext, nil, "404.tmpl")
   if err != nil {
     log.Println(err)
     return

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -44,7 +44,6 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
   resp, err := http.Get(url)
   if err != nil {
     fmt.Printf("Failed to query URL: %v\n", err)
-    isError = true
     RenderError(w, sc)
     return
   }

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -36,7 +36,7 @@ func NewMusicController(s *myradio.Session, c *structs.Config) *MusicController 
 // Get handles the HTTP GET request r for the Music page, writing to w.
 func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
   // URL of the RSS feed to query
-  url := "https://medium.com/feed/@urymusic"
+  url := sc.config.Music.RSSFeed
 
   isError := false
 

--- a/controllers/music.go
+++ b/controllers/music.go
@@ -6,7 +6,6 @@ import (
   "encoding/xml"
 	"fmt"
 	"io/ioutil"
-  "regexp"
 
 	"github.com/UniversityRadioYork/2016-site/structs"
 	"github.com/UniversityRadioYork/2016-site/utils"
@@ -71,7 +70,7 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
   // set content of each post to to scrape the first <em> tag
   for i := range rss.Channel.Items {
     var text string
-    text, err = ExtractFirstEmTagContent(string(rss.Channel.Items[i].Content))
+    text, err = utils.ExtractFirstEmTagContent(string(rss.Channel.Items[i].Content))
     if err == nil {
       rss.Channel.Items[i].Content = text
     }
@@ -91,13 +90,4 @@ func (sc *MusicController) Get(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
-}
-
-func ExtractFirstEmTagContent(htmlStr string) (string, error) {
-	re := regexp.MustCompile(`(?i)<em>(.*?)</em>`)
-	match := re.FindStringSubmatch(htmlStr)
-	if len(match) == 2 {
-		return match[1], nil
-	}
-	return "", fmt.Errorf("no <em> tag found")
 }

--- a/controllers/static.go
+++ b/controllers/static.go
@@ -55,6 +55,14 @@ func (staticC *StaticController) GetCompetitions(w http.ResponseWriter, r *http.
 	}
 }
 
+func (staticC *StaticController) GetMusic(w http.ResponseWriter, r *http.Request) {
+  err := utils.RenderTemplate(w, staticC.config.PageContext, nil, "music.tmpl")
+  if err != nil {
+    log.Println(err)
+    return
+  }
+}
+
 func (staticC *StaticController) GetCIN(w http.ResponseWriter, r *http.Request) {
 	err := utils.RenderTemplate(w, staticC.config.PageContext, nil, "cin.tmpl")
 	if err != nil {

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -397,3 +397,15 @@ body {
   flex-grow: 1;
   background-color: $off-white-color;
 }
+
+.stretched-link {
+  &::#{after} {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: after;
+    content: "";
+  }
+}

--- a/server.go
+++ b/server.go
@@ -124,6 +124,7 @@ func NewServer(c *structs.Config) (*Server, error) {
 	getRouter.HandleFunc("/about/", staticC.GetAbout)
 	getRouter.HandleFunc("/contact/", staticC.GetContact)
 	getRouter.HandleFunc("/competitions/", staticC.GetCompetitions)
+
 	// Candidate Interview Night Routes
 	if c.PageContext.CIN {
 		getRouter.HandleFunc("/cin/", staticC.GetCIN)

--- a/server.go
+++ b/server.go
@@ -117,11 +117,13 @@ func NewServer(c *structs.Config) (*Server, error) {
 	signupC := controllers.NewSignUpController(session, c)
 	postRouter.HandleFunc("/signup/", signupC.Post)
 
+  musicC := controllers.NewMusicController(session, c)
+  getRouter.HandleFunc("/music/", musicC.Get)
+
 	staticC := controllers.NewStaticController(c)
 	getRouter.HandleFunc("/about/", staticC.GetAbout)
 	getRouter.HandleFunc("/contact/", staticC.GetContact)
 	getRouter.HandleFunc("/competitions/", staticC.GetCompetitions)
-
 	// Candidate Interview Night Routes
 	if c.PageContext.CIN {
 		getRouter.HandleFunc("/cin/", staticC.GetCIN)

--- a/structs/config.go
+++ b/structs/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	PageContext    PageContext     `toml:"pageContext"`
 	Schedule       ScheduleConfig  `toml:"schedule"`
 	ShortURLs      ShortURLsConfig `toml:"shortUrls"`
+  Music          MusicConfig     `toml:"music"`
 	TrustedProxies []string        `toml:"trustedProxies"`
 }
 
@@ -108,6 +109,10 @@ type gmaps struct {
 type ShortURLsConfig struct {
 	// UpdateInterval is how often the short URLs should be refreshed, in seconds.
 	UpdateInterval uint `toml:"updateInterval"`
+}
+
+type MusicConfig struct {
+  RSSFeed string `toml:"rssFeed"`
 }
 
 type tomlTime struct {

--- a/utils/date.go
+++ b/utils/date.go
@@ -197,3 +197,13 @@ func coerceTime(raw interface{}) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("invalid time type: %T", raw)
 	}
 }
+
+func FormatRSSDate(dateString string, layout string) (string, error) {
+	t, err := time.Parse(layout, dateString)
+	if err != nil {
+		fmt.Println("Error parsing date:", err)
+		return "", err
+	}
+	formattedDate := t.Format("02 Jan 2006")
+	return formattedDate, err
+}

--- a/utils/get_em.go
+++ b/utils/get_em.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"regexp"
+  "fmt"
+)
+
+// Extract first em tag from html string
+func ExtractFirstEmTagContent(htmlStr string) (string, error) {
+	re := regexp.MustCompile(`(?i)<em>(.*?)</em>`)
+	match := re.FindStringSubmatch(htmlStr)
+	if len(match) == 2 {
+		return match[1], nil
+	}
+	return "", fmt.Errorf("no <em> tag found")
+}

--- a/views/music.tmpl
+++ b/views/music.tmpl
@@ -1,0 +1,26 @@
+{{define "title"}}{{.PageContext.ShortName}} | Music{{end}}
+{{define "content"}}
+<div class="container-fluid banner-2">
+  <div class="container">
+    <div class="row align-items-center text-center">
+      <div class="col">
+        <h1 class="display-3">The Music Team Blog</h1>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="container-fluid container-padded bg-off-white">
+  <div class="container d-flex flex-column align-items-center">
+    {{range .PageData}}
+      <div class="card my-3 w-75">
+        <div class="card-body">
+            <h2 class="card-title"><a target="_blank" class="stretched-link" href="{{.Link}}">{{.Title}}</a></h2>
+            <p class="card-text">Published on {{.PubDate}}</p>
+            <p class="card-text">{{.Content}}</p>
+            <a href="{{.Link}}" target="_blank" class="btn btn-primary">Read More</a>
+        </div>
+      </div>
+    {{end}}
+  </div>
+</div>
+{{end}}

--- a/views/music.tmpl
+++ b/views/music.tmpl
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row align-items-center text-center">
       <div class="col">
-        <h1 class="display-3">The Music Team Blog</h1>
+        <h1 class="display-3">Music Blog</h1>
       </div>
     </div>
   </div>
@@ -12,15 +12,21 @@
 <div class="container-fluid container-padded bg-off-white">
   <div class="container d-flex flex-column align-items-center">
     {{range .PageData}}
-      <div class="card my-3 w-75">
+      <div class="card my-3 w-75 shadow rouded">
         <div class="card-body">
-            <h2 class="card-title"><a target="_blank" class="stretched-link" href="{{.Link}}">{{.Title}}</a></h2>
-            <p class="card-text">Published on {{.PubDate}}</p>
+            <h2 class="card-title mb-1"><a target="_blank" class="stretched-link" href="{{.Link}}">{{.Title}}</a></h2>
+            <p class="card-text text-secondary">Published on {{.PubDate}}</p>
             <p class="card-text">{{.Content}}</p>
-            <a href="{{.Link}}" target="_blank" class="btn btn-primary">Read More</a>
         </div>
       </div>
     {{end}}
+    <div class="card my-3 w-75 shadow-lg rouded">
+      <div class="card-body d-flex justify-content-center">
+        <a href="https://medium.com/@urymusic" target="_blank" class="stretched-link">
+          <h3>More Posts</h3>
+        </a>
+      </div>
+    </div>
   </div>
 </div>
 {{end}}

--- a/views/music.tmpl
+++ b/views/music.tmpl
@@ -23,7 +23,7 @@
     <div class="card my-3 w-75 shadow-lg rouded">
       <div class="card-body d-flex justify-content-center">
         <a href="https://medium.com/@urymusic" target="_blank" class="stretched-link">
-          <h3>More Posts</h3>
+          <h3 class="m-0">More Posts</h3>
         </a>
       </div>
     </div>


### PR DESCRIPTION
Simple list of articles pulled from mediums RSS feed
Requires one addition to config 

Initially open to comment from music team but limited in scope as to what is provided by RSS feed and also I don't want to dump their HTML onto the website.

```toml
[music]
	rssFeed = "https://medium.com/feed/@urymusic"
```