### PR TITLE
Improve podcast handling

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -5,9 +5,11 @@ package controllers
 */
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/UniversityRadioYork/2016-site/structs"
+	"github.com/UniversityRadioYork/2016-site/utils"
 	"github.com/UniversityRadioYork/myradio-go"
 )
 
@@ -31,48 +33,78 @@ type Controller struct {
 // Get handles a HTTP GET request r, writing to w.
 //
 // Unless overridden, controllers refuse this method.
-func (c *Controller) Get(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Method Not Allowed", 405)
+func (*Controller) Get(w http.ResponseWriter, _ *http.Request) {
+	notAllowed(w)
 }
 
 // Post handles a HTTP POST request r, writing to w.
 //
 // Unless overridden, controllers refuse this method.
-func (c *Controller) Post(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Method Not Allowed", 405)
+func (*Controller) Post(w http.ResponseWriter, _ *http.Request) {
+	notAllowed(w)
 }
 
 // Delete handles a HTTP DELETE request r, writing to w.
 //
 // Unless overridden, controllers refuse this method.
-func (c *Controller) Delete(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Method Not Allowed", 405)
+func (*Controller) Delete(w http.ResponseWriter, _ *http.Request) {
+	notAllowed(w)
 }
 
 // Put handles a HTTP PUT request r, writing to w.
 //
 // Unless overridden, controllers refuse this method.
-func (c *Controller) Put(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Method Not Allowed", 405)
+func (*Controller) Put(w http.ResponseWriter, _ *http.Request) {
+	notAllowed(w)
 }
 
 // Head handles a HTTP HEAD request r, writing to w.
 //
 // Unless overridden, controllers refuse this method.
-func (c *Controller) Head(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Method Not Allowed", 405)
+func (*Controller) Head(w http.ResponseWriter, _ *http.Request) {
+	notAllowed(w)
 }
 
 // Patch handles a HTTP PATCH request r, writing to w.
 //
 // Unless overridden, controllers refuse this method.
-func (c *Controller) Patch(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Method Not Allowed", 405)
+func (*Controller) Patch(w http.ResponseWriter, _ *http.Request) {
+	notAllowed(w)
 }
 
 // Options handles a HTTP OPTIONS request r, writing to w.
 //
 // Unless overridden, controllers refuse this method.
-func (c *Controller) Options(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Method Not Allowed", 405)
+func (*Controller) Options(w http.ResponseWriter, _ *http.Request) {
+	notAllowed(w)
+}
+
+// notAllowed sends a HTTP Method Not Allowed error.
+func notAllowed(w http.ResponseWriter) {
+	http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+}
+
+// notFound renders a 404 Not Found error originating from this controller.
+// It takes an optional error that represents the failure to find something,
+// and passes it into the template.
+//
+// This shouldn't be confused with NotFoundController, which handles 404s
+// originating from the user asking for a URL that doesn't exist.
+func (c *Controller) notFound(w http.ResponseWriter, err error) {
+	// TODO(@MattWindsor91): what about non-404 errors?  how do we handle those?
+	if err != nil {
+		log.Println(err)
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+	c.renderTemplate(w, err, "404.tmpl")
+}
+
+// renderTemplate renders a template from this Controller's page context.
+func (c *Controller) renderTemplate(w http.ResponseWriter, data interface{}, mainTmpl string, addTmpls ...string) {
+	if err := utils.RenderTemplate(w, c.config.PageContext, data, mainTmpl, addTmpls...); err != nil {
+		// TODO(@MattWindsor91): handle error more gracefully
+		log.Println(err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
 }

--- a/controllers/not_found.go
+++ b/controllers/not_found.go
@@ -2,11 +2,12 @@ package controllers
 
 import (
 	"fmt"
-	"github.com/UniversityRadioYork/2016-site/models"
-	"github.com/UniversityRadioYork/myradio-go"
 	"log"
 	"net"
 	"net/http"
+
+	"github.com/UniversityRadioYork/2016-site/models"
+	"github.com/UniversityRadioYork/myradio-go"
 
 	"github.com/UniversityRadioYork/2016-site/structs"
 	"github.com/UniversityRadioYork/2016-site/utils"
@@ -56,10 +57,5 @@ func (sc *NotFoundController) Get(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, shortUrl.RedirectTo, http.StatusTemporaryRedirect)
 		return
 	}
-	w.WriteHeader(404)
-	err := utils.RenderTemplate(w, sc.config.PageContext, nil, "404.tmpl")
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	sc.notFound(w, nil)
 }

--- a/controllers/podcasts.go
+++ b/controllers/podcasts.go
@@ -15,18 +15,20 @@ import (
 // PodcastController is the controller for the URYPlayer Podcast pages.
 type PodcastController struct {
 	Controller
+	model *models.PodcastModel
 }
 
 // NewPodcastController returns a new PodcastController with the MyRadio session s
 // and configuration context c.
 func NewPodcastController(s *myradio.Session, c *structs.Config) *PodcastController {
-	return &PodcastController{Controller{session: s, config: c}}
+	return &PodcastController{
+		Controller: Controller{session: s, config: c},
+		model:      models.NewPodcastModel(s),
+	}
 }
 
 // GetAllPodcasts handles the HTTP GET request r for the all postcasts page, writing to w.
 func (podcastsC *PodcastController) GetAllPodcasts(w http.ResponseWriter, r *http.Request) {
-	podcastm := models.NewPodcastModel(podcastsC.session)
-
 	vars := mux.Vars(r)
 
 	pageNumber, _ := strconv.Atoi(vars["page"])
@@ -37,14 +39,14 @@ func (podcastsC *PodcastController) GetAllPodcasts(w http.ResponseWriter, r *htt
 	pageNumberNext := pageNumber + 1
 
 	//podcast page offset is indexed from 0, URL's are from 1.
-	podcasts, err := podcastm.GetAllPodcasts(10, pageNumber-1)
+	podcasts, err := podcastsC.model.GetAllPodcasts(10, pageNumber-1)
 	if podcasts == nil {
 		podcastsC.notFound(w, err)
 		return
 	}
 
 	//see if it's possible to load another podcast for a possible next page.
-	nextPodcasts, _ := podcastm.GetAllPodcasts(1, pageNumber)
+	nextPodcasts, _ := podcastsC.model.GetAllPodcasts(1, pageNumber)
 
 	var pageNext = false
 	if nextPodcasts != nil {
@@ -108,7 +110,7 @@ func (podcastsC *PodcastController) getPodcast(r *http.Request) (*myradio.Podcas
 		return nil, err
 	}
 
-	return models.NewPodcastModel(podcastsC.session).Get(id)
+	return podcastsC.model.Get(id)
 }
 
 func (podcastsC *PodcastController) renderPodcast(w http.ResponseWriter, podcast *myradio.Podcast, tmpl string) {

--- a/controllers/podcasts.go
+++ b/controllers/podcasts.go
@@ -39,10 +39,11 @@ func (podcastsC *PodcastController) GetAllPodcasts(w http.ResponseWriter, r *htt
 
 	//podcast page offset is indexed from 0, URL's are from 1.
 	podcasts, err := podcastm.GetAllPodcasts(10, pageNumber-1)
-
 	if podcasts == nil {
 		podcastsC.render404(w, err)
+		return
 	}
+
 	//see if it's possible to load another podcast for a possible next page.
 	nextPodcasts, _ := podcastm.GetAllPodcasts(1, pageNumber)
 

--- a/controllers/podcasts.go
+++ b/controllers/podcasts.go
@@ -91,12 +91,13 @@ func (podcastsC *PodcastController) GetEmbed(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		//@TODO: Do something proper here, render 404 or something
 		log.Println(err)
+		http.NotFound(w, r)
 		return
 	}
 
 	// No error, but podcast is not available
 	if podcast == nil {
-		//@TODO: Do something proper here, render 404 or something
+		http.NotFound(w, r)
 		return
 	}
 

--- a/controllers/podcasts.go
+++ b/controllers/podcasts.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/UniversityRadioYork/2016-site/models"
 	"github.com/UniversityRadioYork/2016-site/structs"
-	"github.com/UniversityRadioYork/2016-site/utils"
 	"github.com/UniversityRadioYork/myradio-go"
 )
 
@@ -40,7 +39,7 @@ func (podcastsC *PodcastController) GetAllPodcasts(w http.ResponseWriter, r *htt
 	//podcast page offset is indexed from 0, URL's are from 1.
 	podcasts, err := podcastm.GetAllPodcasts(10, pageNumber-1)
 	if podcasts == nil {
-		podcastsC.render404(w, err)
+		podcastsC.notFound(w, err)
 		return
 	}
 
@@ -52,7 +51,7 @@ func (podcastsC *PodcastController) GetAllPodcasts(w http.ResponseWriter, r *htt
 		pageNext = true
 	}
 	if err != nil {
-		podcastsC.render404(w, err)
+		podcastsC.notFound(w, err)
 		return
 	}
 
@@ -78,7 +77,7 @@ func (podcastsC *PodcastController) Get(w http.ResponseWriter, r *http.Request) 
 	podcast, err := podcastsC.getPodcast(r)
 	if podcast == nil || err != nil {
 		// TODO(@MattWindsor91): what if the error is not 404?
-		podcastsC.render404(w, err)
+		podcastsC.notFound(w, err)
 		return
 	}
 
@@ -89,7 +88,6 @@ func (podcastsC *PodcastController) Get(w http.ResponseWriter, r *http.Request) 
 func (podcastsC *PodcastController) GetEmbed(w http.ResponseWriter, r *http.Request) {
 	podcast, err := podcastsC.getPodcast(r)
 	if err != nil {
-		//@TODO: Do something proper here, render 404 or something
 		log.Println(err)
 		http.NotFound(w, r)
 		return
@@ -120,23 +118,4 @@ func (podcastsC *PodcastController) renderPodcast(w http.ResponseWriter, podcast
 		Podcast: podcast,
 	}
 	podcastsC.renderTemplate(w, data, tmpl)
-}
-
-func (podcastsC *PodcastController) render404(w http.ResponseWriter, err error) {
-	// TODO(@MattWindsor91): aren't some of these 500s and not 404s?
-	if err != nil {
-		log.Println(err)
-	}
-
-	// TODO(@MattWindsor91): maybe bounce into not_found somehow rather than just using the template
-	podcastsC.renderTemplate(w, err, "404.tmpl")
-}
-
-func (podcastsC *PodcastController) renderTemplate(w http.ResponseWriter, data interface{}, mainTmpl string, addTmpls ...string) {
-	// TODO(@MattWindsor91): I think this can be pushed into *Controller
-	if err := utils.RenderTemplate(w, podcastsC.config.PageContext, data, mainTmpl, addTmpls...); err != nil {
-		// TODO(@MattWindsor91): handle error more gracefully
-		log.Println(err)
-		return
-	}
 }

--- a/models/podcasts.go
+++ b/models/podcasts.go
@@ -33,6 +33,18 @@ func (m *PodcastModel) GetAllPodcasts(number int, page int) (podcasts []myradio.
 }
 
 // Get gets the data required for the Podcast controller from MyRadio.
-func (m *PodcastModel) Get(id int) (podcast *myradio.Podcast, err error) {
-	return m.session.GetPodcastWithShow(id)
+// It does not retrieve a podcast if the podcast is unpublished.
+func (m *PodcastModel) Get(id int) (*myradio.Podcast, error) {
+	pod, err := m.session.GetPodcastWithShow(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// we should not show unpublished podcasts, regardless of situation
+	// (https://github.com/UniversityRadioYork/2016-site/issues/269)
+	if pod.Status != "Published" {
+		return nil, nil
+	}
+
+	return pod, nil
 }


### PR DESCRIPTION
Predominantly an attempt to fix #269, but I've also done a few minor changes (mostly DRY) round the edges.

In ascending order of potential controversy:

- The model code now performs the check to see if podcasts are published, so all endpoints depending on the model now only see published podcasts.
- The podcast player uses the Go builtin `http.NotFound` if it 404s, so at least there's an error thrown, even if it's ugly as sin.  (I presumed that using the normal URY 404 would be silly - it won't render well in an embed.)
- The podcast controller eagerly constructs a model in its constructor, since all of its endpoints depend on having the model around.
- I've pulled out 404 handling code from both the not-found and podcasts controllers into one bit of code, which is currently in `controllers` but can be moved.
- I've also pulled out the idea of handling a template using the page context of a controller into a private method of `Controller`, which might be useful, or it might be overly coupling templates and controllers, comments welcome.

I'd love to do more to improve the error handling here, but I think I need more structured error information from `myradio-go`.