### PR TITLE
Improve IndexModel error handling

### DIFF
--- a/models/index.go
+++ b/models/index.go
@@ -1,7 +1,9 @@
 package models
 
 import (
-	myradio "github.com/UniversityRadioYork/myradio-go"
+	"fmt"
+
+	"github.com/UniversityRadioYork/myradio-go"
 )
 
 // IndexModel is the model for the Index controller.
@@ -22,14 +24,17 @@ func NewIndexModel(s *myradio.Session) *IndexModel {
 func (m *IndexModel) Get() (currentAndNext *myradio.CurrentAndNext, banners []myradio.Banner, timeslots []myradio.Timeslot, podcasts []myradio.Podcast, showOnAir bool, err error) {
 	currentAndNext, err = m.session.GetCurrentAndNext()
 	if err != nil {
+		err = fmt.Errorf("failed to GetCurrentAndNext: %w", err)
 		return
 	}
 	banners, err = m.session.GetLiveBanners()
 	if err != nil {
+		err = fmt.Errorf("failed to GetLiveBanners: %w", err)
 		return
 	}
 	timeslots, err = m.session.GetPreviousTimeslots(11)
 	if err != nil {
+		err = fmt.Errorf("failed to GetPreviousTimeslots: %w", err)
 		return
 	}
 	// If show currently on air, remove it from previous timeslots
@@ -39,6 +44,7 @@ func (m *IndexModel) Get() (currentAndNext *myradio.CurrentAndNext, banners []my
 	//Get 10 podcasts from page 0 (the latest podcasts)
 	allpodcasts, err := m.session.GetAllPodcasts(10, 0, false)
 	if err != nil {
+		err = fmt.Errorf("failed to GetAllPodcasts: %w", err)
 		return
 	}
 


### PR DESCRIPTION
We weren't wrapping the errors at all, so the only logging we got about errors was

```
/home/deploy/workspace/2016-site/controllers/index.go:42: strconv.ParseInt: parsing "false": invalid syntax
```

This should at least make it clearer when it goes wrong again.