### PR TITLE
Adds drop shadow to pride image

### DIFF
--- a/sass/elements/_navbar.scss
+++ b/sass/elements/_navbar.scss
@@ -18,10 +18,10 @@ $nav-links-color: rgb(2, 45, 89);
   }
 
   .navbar-pride-logo {
-    -webkit-filter: drop-shadow(1px 1px -2px black)
-                    drop-shadow(-1px -1px 2px black);
-    filter: drop-shadow(-0.5px -0.5px 0 black) 
-            drop-shadow(0.5px 0.5px 0 black);
+    -webkit-filter: drop-shadow(0.75px 0.75px -2px black)
+                    drop-shadow(-0.75px -0.75px 2px black);
+    filter: drop-shadow(0.75px 0.75px 0 black) 
+            drop-shadow(-0.75px -0.75px 0 black);
   }
   
   

--- a/sass/elements/_navbar.scss
+++ b/sass/elements/_navbar.scss
@@ -17,6 +17,14 @@ $nav-links-color: rgb(2, 45, 89);
     color: $nav-links-color;
   }
 
+  .navbar-pride-logo {
+    -webkit-filter: drop-shadow(1px 1px -2px black)
+                    drop-shadow(-1px -1px 2px black);
+    filter: drop-shadow(-0.5px -0.5px 0 black) 
+            drop-shadow(0.5px 0.5px 0 black);
+  }
+  
+  
   .navbar-toggler {
     line-height: inherit;
     right: 0;
@@ -25,4 +33,5 @@ $nav-links-color: rgb(2, 45, 89);
       background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(0, 0, 0, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E");
     }
   }
+
 }

--- a/sass/elements/_navbar.scss
+++ b/sass/elements/_navbar.scss
@@ -18,8 +18,8 @@ $nav-links-color: rgb(2, 45, 89);
   }
 
   .navbar-pride-logo {
-    -webkit-filter: drop-shadow(0.75px 0.75px -2px black)
-                    drop-shadow(-0.75px -0.75px 2px black);
+    -webkit-filter: drop-shadow(0.75px 0.75px 0px black)
+                    drop-shadow(-0.75px -0.75px 0px black);
     filter: drop-shadow(0.75px 0.75px 0 black) 
             drop-shadow(-0.75px -0.75px 0 black);
   }

--- a/sass/elements/_navbar.scss
+++ b/sass/elements/_navbar.scss
@@ -18,8 +18,8 @@ $nav-links-color: rgb(2, 45, 89);
   }
 
   .navbar-pride-logo {
-    -webkit-filter: drop-shadow(0.75px 0.75px 0px black)
-                    drop-shadow(-0.75px -0.75px 0px black);
+    -webkit-filter: drop-shadow(0.75px 0.75px 0 black)
+                    drop-shadow(-0.75px -0.75px 0 black);
     filter: drop-shadow(0.75px 0.75px 0 black) 
             drop-shadow(-0.75px -0.75px 0 black);
   }

--- a/views/elements/navbar.tmpl
+++ b/views/elements/navbar.tmpl
@@ -6,9 +6,9 @@
     </button>
     <a class="navbar-brand" href="{{url "/"}}">
     {{if .PageContext.Pride}}
-      <img src="{{url "/images/URY_Rainbow.png"}}" height="34" alt="{{.PageContext.LongName}} Logo" >
+        <img class="navbar-pride-logo" src="{{url "/images/URY_Rainbow.png"}}" height="34" alt="{{.PageContext.LongName}} Logo" >
     {{else}}
-      <img src="{{url "/images/logo.png"}}" height="34" alt="{{.PageContext.LongName}} Logo" >
+        <img src="{{url "/images/logo.png"}}" height="34" alt="{{.PageContext.LongName}} Logo" >
     {{end}}
     </a>
     <div class="navbar-collapse collapse" id="collapsed">


### PR DESCRIPTION
I added a bit drop shadow as others have suggested to make the pride logo look a bit better.
Given the website uses white as a background.

Before:
![image](https://github.com/UniversityRadioYork/2016-site/assets/63605841/50baacac-4b4d-4ba0-adc4-36952dbef6d2)


After:
![image](https://github.com/UniversityRadioYork/2016-site/assets/63605841/b81ef578-a2ff-4e21-b8b5-c903c9395f65)



