### PR TITLE
Fix broken Jukebox image on Mobile Schedule

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -79,4 +79,4 @@
 	[schedule.sustainer]
 		name = "Overnight Owen"
 		desc = "Non-stop tunes from the URY jukebox."
-		image = "//media/image_meta/ShowImageMetadata/22.png"
+		image = "/media/image_meta/ShowImageMetadata/22.png"

--- a/config.toml.example
+++ b/config.toml.example
@@ -79,4 +79,4 @@
 	[schedule.sustainer]
 		name = "Overnight Owen"
 		desc = "Non-stop tunes from the URY jukebox."
-		image = "//ury.org.uk/media/image_meta/ShowImageMetadata/22.png"
+		image = "//media/image_meta/ShowImageMetadata/22.png"


### PR DESCRIPTION
Removes leading "ury.org.uk" on sustainer image config, as is unnessecary