### PR TITLE
fix: lazy-load schedule show art

### DIFF
--- a/views/schedule_week.tmpl
+++ b/views/schedule_week.tmpl
@@ -142,7 +142,7 @@
           <ul class="p-0">
             {{range .Shows}}
               <li class="schedule-card">
-                <img src="https://ury.org.uk{{.ShowArtURL}}" width="128" height="128">
+                <img src="https://ury.org.uk{{.ShowArtURL}}" width="128" height="128" loading="lazy">
                 <div class="card-details pb-0">
                   <h3>
                     {{if .PageURL}}


### PR DESCRIPTION
## Summary

- Add native lazy loading to show art images in the weekly schedule list.

## Related Issue

Closes #411.

## Validation

- `go test ./...`
- `git diff --check`
- `git diff --cached --check`
- `gitleaks protect --staged --no-banner --redact`

## Notes

This keeps the existing image dimensions and markup structure intact, only adding `loading="lazy"` to defer off-screen show art downloads.
