### PR TITLE
Lazy-load schedule show art images

### DIFF
--- a/views/schedule_week.tmpl
+++ b/views/schedule_week.tmpl
@@ -142,7 +142,7 @@
           <ul class="p-0">
             {{range .Shows}}
               <li class="schedule-card">
-                <img src="https://ury.org.uk{{.ShowArtURL}}" width="128" height="128">
+                <img src="https://ury.org.uk{{.ShowArtURL}}" width="128" height="128" loading="lazy">
                 <div class="card-details pb-0">
                   <h3>
                     {{if .PageURL}}


### PR DESCRIPTION
Fixes #411.

## Summary

- Add native lazy loading to schedule card show-art images.
- Keep the change limited to the schedule week template.

## Verification

- Confirmed the local diff only updates the schedule show-art `<img>` tag.
- `go test ./...`

## Notes

This is intended to avoid eagerly fetching every show-art image on desktop when those schedule card images are not visible.